### PR TITLE
Correctly export billing account name

### DIFF
--- a/terraform/modules/billing/outputs.tf
+++ b/terraform/modules/billing/outputs.tf
@@ -1,4 +1,4 @@
 output "billing_account" {
   description = "Billing account, default. Used for most projects."
-  value       = data.google_billing_account.default
+  value       = data.google_billing_account.default.name
 }


### PR DESCRIPTION
Instead of exporting an object, export the discrete billing account
name.