### PR TITLE
Add billing_account to root module outputs

### DIFF
--- a/terraform/org/outputs.tf
+++ b/terraform/org/outputs.tf
@@ -1,0 +1,4 @@
+output "billing_account" {
+  value = module.billing.billing_account
+  description = ""
+}


### PR DESCRIPTION
Adds billing account to root module outputs, so it can be read from
remote state in other configurations.