### PR TITLE
Upgrade google providers to latest

### DIFF
--- a/terraform/org/versions.tf
+++ b/terraform/org/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "0.14.9"
 
   required_providers {
-    google      = "3.46.0"
-    google-beta = "3.46.0"
+    google      = "3.50.0"
+    google-beta = "3.50.0"
   }
 }


### PR DESCRIPTION
Upgrades `hashicorp/google` and `hashicorp/google-beta` providers to
their latest release.