### PR TITLE
Give org admins access to Terraform SA

### DIFF
--- a/terraform/modules/workspace/main.tf
+++ b/terraform/modules/workspace/main.tf
@@ -28,3 +28,15 @@ resource "google_folder_iam_member" "terraform_service_account_workspace_editor"
   role        = "roles/editor"
   member      = "serviceAccount:${google_service_account.terraform.email}"
 }
+
+resource "google_service_account_iam_binding" "admins_terraform_user" {
+  service_account_id = google_service_account.terraform.name
+  role               = "roles/iam.serviceAccountUser"
+  members            = var.org_admins
+}
+
+resource "google_service_account_iam_binding" "admins_terraform_token_creator" {
+  service_account_id = google_service_account.terraform.name
+  role               = "roles/iam.serviceAccountTokenCreator"
+  members            = var.org_admins
+}

--- a/terraform/modules/workspace/variables.tf
+++ b/terraform/modules/workspace/variables.tf
@@ -8,6 +8,11 @@ variable "name" {
   description = "Workspace name. Should be unique in the organization."
 }
 
+variable "org_admins" {
+  type        = set(string)
+  description = "List of users who are assigned to administer the organization."
+}
+
 variable "org_id" {
   type        = string
   description = "Organization ID, where resources are created."

--- a/terraform/org/main.tf
+++ b/terraform/org/main.tf
@@ -33,5 +33,6 @@ module "web" {
   name = "web"
 
   billing_account = module.billing.billing_account
+  org_admins      = module.org.org_admins
   org_id          = module.org.org_id
 }

--- a/terraform/org/outputs.tf
+++ b/terraform/org/outputs.tf
@@ -19,6 +19,6 @@ output "web_folder" {
 }
 
 output "web_service_account_email" {
-  description = "Folder where workspace resources are created."
+  description = "Email of the Terrraform service account managing the workspace."
   value       = module.web.service_account_email
 }


### PR DESCRIPTION
Allows admins to manage the Terraform service account for a given
workspace.