### PR TITLE
Use service account tokens for access

### DIFF
--- a/terraform/modules/access-token-resolver/main.tf
+++ b/terraform/modules/access-token-resolver/main.tf
@@ -1,0 +1,7 @@
+data "google_service_account_access_token" "service_account_access_token" {
+  provider = google
+
+  lifetime               = "300s"
+  scopes                 = ["cloud-platform", "userinfo-email"]
+  target_service_account = var.target_service_account
+}

--- a/terraform/modules/access-token-resolver/outputs.tf
+++ b/terraform/modules/access-token-resolver/outputs.tf
@@ -1,0 +1,4 @@
+output "access_token" {
+  description = "Access token for authorizing Google API requests, if requested."
+  value       = data.google_service_account_access_token.service_account_access_token.access_token
+}

--- a/terraform/modules/access-token-resolver/variables.tf
+++ b/terraform/modules/access-token-resolver/variables.tf
@@ -1,0 +1,4 @@
+variable "target_service_account" {
+  description = "The service account to obtain an access token for."
+  type        = string
+}

--- a/terraform/web/auth.tf
+++ b/terraform/web/auth.tf
@@ -1,0 +1,22 @@
+module "access_token_resolver" {
+  source = "../modules/access-token-resolver"
+
+  target_service_account = data.terraform_remote_state.org.outputs.web_service_account_email
+
+  providers = {
+    google = google.access_token_resolver
+  }
+}
+
+
+provider "google" {
+  alias  = "access_token_resolver"
+}
+
+provider "google" {
+  access_token = module.access_token_resolver.access_token
+}
+
+provider "google-beta" {
+  access_token = module.access_token_resolver.access_token
+}

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -9,3 +9,14 @@ terraform {
   }
 }
 
+data "terraform_remote_state" "org" {
+  backend = "remote"
+
+  config = {
+    hostname     = "app.terraform.io"
+    organization = "langri-sha"
+    workspaces = {
+      name = "org"
+    }
+  }
+}


### PR DESCRIPTION
Configures access to Google providers using the web workspace TF service
account's access token.