### PR TITLE
Ignore Terraform soorces from Docker build context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 !.babelrc
+!.dockerignore
 !.editorconfig
 !.eslintrc
 !.flowconfig

--- a/terraform/.dockerignore
+++ b/terraform/.dockerignore
@@ -1,0 +1,5 @@
+cloudbuild.yml
+
+modules/
+org/
+web/


### PR DESCRIPTION
Ensures TF sources are not included in the Docker build context.

Fixes #147.