### PR TITLE
Use double quotes for entrypoint

### DIFF
--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -34,4 +34,4 @@ RUN gcloud config set core/disable_usage_reporting true \
 	&& gcloud --version \
 	&& terraform --version
 
-ENTRYPOINT ['terraform']
+ENTRYPOINT ["terraform"]


### PR DESCRIPTION
Fixes use of single quotes for entrypoint.

Fixes #147.