### PR TITLE
Pull built image when tagging

### DIFF
--- a/terraform/cloudbuild.yaml
+++ b/terraform/cloudbuild.yaml
@@ -57,6 +57,10 @@ steps:
       - |
         set -e
 
+        if [ -f /var/share/pull ]; then
+          docker pull gcr.io/$PROJECT_ID/terraform:$(cat /var/share/tag)
+        fi
+
         docker tag gcr.io/$PROJECT_ID/terraform:$(cat /var/share/tag) gcr.io/$PROJECT_ID/terraform:latest
     waitFor: ['Build Terraform image']
 


### PR DESCRIPTION
Before creating a tag, ensure the newly built image is pulled, as it
doesn't already exist in the local Docker host.

Fixes #156.