### PR TITLE
Replace deprecated interpolate-only expression

### DIFF
--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -24,7 +24,7 @@ locals {
 
   host_names = {
     "www"               = "www.${data.terraform_remote_state.org.outputs.org_domain}",
-    "production"        = "${data.terraform_remote_state.org.outputs.org_domain}",
+    "production"        = data.terraform_remote_state.org.outputs.org_domain,
     "production-assets" = "assets.${data.terraform_remote_state.org.outputs.org_domain}",
     "preview"           = "preview.${data.terraform_remote_state.org.outputs.org_domain}",
     "preview-assets"    = "assets.preview.${data.terraform_remote_state.org.outputs.org_domain}",


### PR DESCRIPTION
Fixes deprecation notice with Terraform.

Fixes #162.