### PR TITLE
Upgrade alpine to latest release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 x-alpine-args: &alpine-args
-  alpine_version: '3.12'
+  alpine_version: '3.13'
 
 x-terraform-args: &terraform-args
   google_cloud_sdk_version: 336.0.0


### PR DESCRIPTION
Updates Alpine to latest release.

See https://alpinelinux.org/posts/Alpine-3.13.0-released.html.