### PR TITLE
Upgrade terraform to latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-node-args: &node-args
 
 x-terraform-args: &terraform-args
   google_cloud_sdk_version: '336.0.0'
-  terraform_version: '0.14.10'
+  terraform_version: '0.15.1'
 
 x-user-args: &user-args
   uid: ${UID:-1000}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ x-node-args: &node-args
   glibc_version: '2.33-r0'
 
 x-terraform-args: &terraform-args
-  google_cloud_sdk_version: 336.0.0
-  terraform_version: 0.14.10
+  google_cloud_sdk_version: '336.0.0'
+  terraform_version: '0.14.10'
 
 x-user-args: &user-args
   uid: ${UID:-1000}

--- a/terraform/org/versions.tf
+++ b/terraform/org/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.14.10"
+  required_version = "0.15.1"
 
   required_providers {
     google      = "3.64.0"

--- a/terraform/web/versions.tf
+++ b/terraform/web/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "0.14.10"
+  required_version = "0.15.1"
 
   required_providers {
     google      = "3.64.0"


### PR DESCRIPTION
Upgrades Terraform to latest release.

See:
https://github.com/hashicorp/terraform/blob/v0.15/CHANGELOG.md#0151-april-26-2021.