### PR TITLE
Restrict workspace push trigger to main branch

### DIFF
--- a/terraform/web/build.tf
+++ b/terraform/web/build.tf
@@ -60,7 +60,7 @@ module "cloudbuild" {
       ignored_files = ["terraform/**"]
 
       push = {
-        branch = ".*"
+        branch = "main"
       }
     },
 


### PR DESCRIPTION
Restrict workspace push trigger to main branch only. Deliniates pushes
to PR branches.

Fixes #182.