### PR TITLE
Upgrade Node.js to latest

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 
 x-alpine-args: &alpine-args
-  alpine_version: '3.13'
+  alpine_version: '3.15'
 
 x-node-args: &node-args
   node_version: '16.4.2'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ x-alpine-args: &alpine-args
   alpine_version: '3.15'
 
 x-node-args: &node-args
-  node_version: '16.4.2'
+  node_version: '16.13.2'
   glibc_version: '2.33-r0'
 
 x-terraform-args: &terraform-args

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "prepare": "husky install"
   },
   "engines": {
-    "node": ">=16.4.2"
+    "node": ">=16.13.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Upgrades Node.js to latest stable release. For January 2022 upgrades.

See:
https://nodejs.org/en/blog/vulnerability/jan-2022-security-releases/.