### PR TITLE
Update Webpack start run script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "main": "src/index.js",
   "scripts": {
-    "start": "webpack serve --progress --open --hot --https --port 8080",
+    "start": "webpack serve --progress --open --hot --port 8080",
     "build": "webpack --env production --progress",
     "test": "webpack --debug --bail",
     "flow-typed-mono": "yarn workspaces run flow-typed --flowVersion $(cat .flowconfig | head -n2 | tail -n1) install --rootDir $(pwd) --skip",


### PR DESCRIPTION
Updates start script to remove unsupported
`--https` flag. Removing it for, for the time
being, instead of migrating.