### PR TITLE
Add reusable Webpack resolve loader

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "webfontloader": "1.6.28"
   },
   "devDependencies": {
+    "@langri-sha/webpack": "1.0.0-next",
     "@langri-sha/babel-preset": "1.0.0-next"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,5 +12,8 @@
   "dependencies": {
     "normalize.css": "8.0.1",
     "webfontloader": "1.6.28"
+  },
+  "devDependencies": {
+    "@langri-sha/babel-preset": "1.0.0-next"
   }
 }

--- a/apps/web/webpack.config.js
+++ b/apps/web/webpack.config.js
@@ -12,6 +12,7 @@ const {
   EnvironmentPlugin,
   HtmlPlugin,
   TerserPlugin,
+  resolveLoader,
 } = require('@langri-sha/webpack')
 
 /* ::
@@ -43,6 +44,7 @@ module.exports = (env(({ development, production }) => ({
       }),
     ],
   },
+  resolveLoader,
   module: {
     rules: [
       {

--- a/packages/webpack/src/index.js
+++ b/packages/webpack/src/index.js
@@ -1,5 +1,8 @@
 // @flow
 
+import path from 'path'
+import type { ResolveOptions } from 'webpack'
+
 // Stock.
 export { default } from 'webpack'
 export const { EnvironmentPlugin } = require('webpack')
@@ -10,3 +13,8 @@ export { CleanWebpackPlugin as CleanPlugin } from 'clean-webpack-plugin'
 export { default as CopyPlugin } from 'copy-webpack-plugin'
 export { default as HtmlPlugin } from 'html-webpack-plugin'
 export { default as TerserPlugin } from 'terser-webpack-plugin'
+
+// Resolve Webpack loaders from this package first.
+export const resolveLoader: ResolveOptions = {
+  modules: [path.join(__dirname, '..', 'node_modules'), 'node_modules'],
+}


### PR DESCRIPTION
Adds a reusable resolve loader to the Webpack package, for use in other
packages that rely on the compiler.
