### PR TITLE
Add apps workspace to Flow

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -2,6 +2,7 @@
 0.169.0
 
 [include]
+apps/**/*.js
 packages/**/*.js
 
 [options]


### PR DESCRIPTION
Adds apps workspace, when including files to cover with Flow.

Fixes #353.