### PR TITLE
Fix `tempy` export

### DIFF
--- a/packages/jest-test/src/index.ts
+++ b/packages/jest-test/src/index.ts
@@ -1,2 +1,2 @@
 export * from '@jest/globals'
-export * as tempy from 'tempy'
+export { default as tempy } from 'tempy'


### PR DESCRIPTION
Fixes module export for `temp`, after it was downgraded to CommonJS.

Fixes #372.