### PR TITLE
Use CommonJS export in `lint-staged` package

### DIFF
--- a/packages/lint-staged/package.json
+++ b/packages/lint-staged/package.json
@@ -8,6 +8,7 @@
     "@types/lint-staged": "13.3.0"
   },
   "peerDependencies": {
-    "lint-staged": "^15.0.0"
+    "lint-staged": "^15.0.0",
+    "prettier": "^2.0.0"
   }
 }

--- a/packages/lint-staged/package.json
+++ b/packages/lint-staged/package.json
@@ -8,6 +8,7 @@
     "@types/lint-staged": "13.3.0"
   },
   "peerDependencies": {
+    "eslint": "^8.0.0",
     "lint-staged": "^15.0.0",
     "prettier": "^2.0.0"
   }

--- a/packages/lint-staged/src/index.js
+++ b/packages/lint-staged/src/index.js
@@ -9,7 +9,7 @@ const eslintCli = new ESLint({
 /**
  * @type {import('lint-staged').Config}
  */
-export default {
+module.exports = {
   '*.{js,jsx}': async (files) => {
     const ignored = await Promise.all(
       files.map(async (file) => [file, await eslintCli.isPathIgnored(file)])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ importers:
       lint-staged:
         specifier: ^15.0.0
         version: 15.2.2
+      prettier:
+        specifier: ^2.0.0
+        version: 2.8.8
     devDependencies:
       '@langri-sha/tsconfig':
         specifier: 1.0.0-next
@@ -6315,7 +6318,6 @@ packages:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
     hasBin: true
-    dev: true
 
   /pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
 
   packages/lint-staged:
     dependencies:
+      eslint:
+        specifier: ^8.0.0
+        version: 8.57.0
       lint-staged:
         specifier: ^15.0.0
         version: 15.2.2


### PR DESCRIPTION
Fixes `@langri-sha/lint-staged` to use CommonJS export.

Fixes https://github.com/langri-sha/langri-sha.com/pull/379.