### PR TITLE
Remove `glibc` from `docker/pnpm`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,3 @@
-x-node-args: &node-args
-  glibc_version: '2.35-r1'
-
 x-user-args: &user-args
   uid: ${UID:-1000}
 
@@ -85,7 +82,7 @@ services:
       cache_from:
         - gcr.io/${PROJECT_ID:-local}/pnpm
       args:
-        <<: [*node-args, *user-args]
+        <<: *user-args
 
   server:
     <<: [*pnpm-svc, *google-dns]

--- a/docker/pnpm/Dockerfile
+++ b/docker/pnpm/Dockerfile
@@ -5,11 +5,8 @@ ARG alpine_version
 FROM node:20.12-alpine3.19
 
 ARG uid
-ARG glibc_version
 
 RUN <<EOF
-wget -q -O /etc/apk/keys/sgerrand.rsa.pub https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub
-wget -q https://github.com/sgerrand/alpine-pkg-glibc/releases/download/${glibc_version}/glibc-${glibc_version}.apk
 apk add --no-cache --update --upgrade \
 	ca-certificates \
 	g++ \
@@ -18,8 +15,6 @@ apk add --no-cache --update --upgrade \
 	openssh \
 	python3 \
 	wget \
-	glibc-${glibc_version}.apk
-rm glibc-${glibc_version}.apk
 
 npm install -g pnpm
 


### PR DESCRIPTION
Removing `glibc`, since it isn't used anymore.