### PR TITLE
Exclude projen config files from git ignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 !.npmignore
 !.openssl
 !.prettierignore
+!.projenrc*
 !.terraform.lock.hcl
 *.db
 *.log

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,0 +1,13 @@
+import { Project } from '@langri-sha/projen-project'
+
+const project = new Project({
+  name: "langri-sha.com",
+  withTypeScript: true,
+  withTerraform: true,
+  workspaces: [
+    'apps/*',
+    'packages/*'
+  ]
+});
+
+project.synth();

--- a/change/@langri-sha-projen-project-a2722372-0718-4e87-a0af-e08fa95febfa.json
+++ b/change/@langri-sha-projen-project-a2722372-0718-4e87-a0af-e08fa95febfa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(projen-project): Unignore projen config files",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -16,6 +16,7 @@ exports[`defaults 1`] = `
 !.npmignore
 !.openssl
 !.prettierignore
+!.projenrc*
 *.db
 *.log
 !.github/
@@ -71,6 +72,7 @@ exports[`with Terraform enabled 1`] = `
 !.npmignore
 !.openssl
 !.prettierignore
+!.projenrc*
 !.terraform.lock.hcl
 *.db
 *.log
@@ -127,6 +129,7 @@ exports[`with TypeScript enabled 1`] = `
 !.npmignore
 !.openssl
 !.prettierignore
+!.projenrc*
 *.db
 *.log
 *.tsbuildinfo
@@ -183,6 +186,7 @@ exports[`with workspaces 1`] = `
 !.npmignore
 !.openssl
 !.prettierignore
+!.projenrc*
 *.db
 *.log
 !.github/

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -76,6 +76,7 @@ const getGitIgnoreOptions = ({
     !.npmignore
     !.openssl
     !.prettierignore
+    !.projenrc*
     ${withTerraform ? '!.terraform.lock.hcl' : ''}
     *.db
     *.log

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "extends": "@langri-sha/tsconfig",
   "files": [
     ".eslintrc.js",
+    ".projenrc.ts",
     "babel.config.js",
     "jest.config.ts",
     "lint-staged.config.js",


### PR DESCRIPTION
Adds missing Git ignore pattern to exclude ignore rules for projen
configuration files.

Fixes https://github.com/langri-sha/langri-sha.com/pull/425.