### PR TITLE
Configure token when setting up Node.js

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -22,6 +22,7 @@ jobs:
           node-version-file: package.json
           registry-url: https://registry.npmjs.org
           scope: '@langri-sha'
+          token: ${{ secrets.NPM_TOKEN }}
 
       - name: Configure Git user
         run: |


### PR DESCRIPTION
Configures NPM token while setting up Node.js.

Fixes #415.