### PR TITLE
Add missing spaces to linted files

### DIFF
--- a/change/@langri-sha-projen-lint-synthesized-834c8ed9-27da-47b7-a989-cdf112f708d8.json
+++ b/change/@langri-sha-projen-lint-synthesized-834c8ed9-27da-47b7-a989-cdf112f708d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(lint-synthesized): Add missing spaces between filenames",
+  "packageName": "@langri-sha/projen-lint-synthesized",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-lint-synthesized/src/index.test.ts
+++ b/packages/projen-lint-synthesized/src/index.test.ts
@@ -41,15 +41,23 @@ test('lints synthesized files', async () => {
     '*': 'prettier --ignore-unknown --write',
   })
 
-  let file
+  let file, contents
 
-  file = new TextFile(project, 'test.js')
+  file = new TextFile(project, 'test1.js')
+  file.addLine(`module.exports = ${JSON.stringify({ foo: 'bar' })}`)
+
+  file = new TextFile(project, 'test2.js')
   file.addLine(`module.exports = ${JSON.stringify({ foo: 'bar' })}`)
 
   project.synth()
 
-  file = await fs.readFile(path.join(project.outdir, 'test.js'))
-  const contents = file.toString('utf8')
+  file = await fs.readFile(path.join(project.outdir, 'test1.js'))
+  contents = file.toString('utf8')
+
+  expect(contents).toEqual(`module.exports = { foo: "bar" };\n`)
+
+  file = await fs.readFile(path.join(project.outdir, 'test2.js'))
+  contents = file.toString('utf8')
 
   expect(contents).toEqual(`module.exports = { foo: "bar" };\n`)
 })

--- a/packages/projen-lint-synthesized/src/index.ts
+++ b/packages/projen-lint-synthesized/src/index.ts
@@ -88,7 +88,7 @@ export class LintSynthesized extends Component {
   #run(files: string[], command: string | ((files: string[]) => string)) {
     const task =
       typeof command === 'string'
-        ? `${command} ${files.join('')}`
+        ? `${command} ${files.join(' ')}`
         : command(files)
 
     debug(`Running command ${task}`)


### PR DESCRIPTION
Adds ommitted space to delimit files for linting when running commands.

Fixes https://github.com/langri-sha/langri-sha.com/pull/435.