### PR TITLE
Replace projen `deepMerge` helper

### DIFF
--- a/change/@langri-sha-projen-project-e5ebcdba-a119-446d-bf0f-8986949ae073.json
+++ b/change/@langri-sha-projen-project-e5ebcdba-a119-446d-bf0f-8986949ae073.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(projen-project): Replace `deepMerge`",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/package.json
+++ b/packages/projen-project/package.json
@@ -6,11 +6,13 @@
   "main": "src/index.ts",
   "dependencies": {
     "@langri-sha/projen-lint-synthesized": "workspace:*",
-    "beachball": "2.43.1"
+    "beachball": "2.43.1",
+    "ramda": "0.29.1"
   },
   "devDependencies": {
     "@langri-sha/jest-test": "workspace:*",
     "@langri-sha/tsconfig": "workspace:*",
+    "@types/ramda": "0.29.12",
     "projen": "0.81.1"
   },
   "peerDependencies": {

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -5,7 +5,7 @@ import {
   YamlFile,
 } from 'projen'
 
-import { deepMerge } from 'projen/lib/util'
+import * as R from 'ramda'
 import { type BeachballConfig } from 'beachball'
 
 import {
@@ -66,20 +66,17 @@ export class Project extends BaseProject {
       return
     }
 
-    const options = deepMerge([
-      beachballConfig,
-      {
-        branch: 'origin/main',
-        gitTags: false,
-        ignorePatterns: [
-          '*.test.*',
-          '.*/**',
-          '__snapshots__/',
-          'dist/',
-          'node_modules/',
-        ],
-      },
-    ])
+    const options = deepMerge(beachballConfig, {
+      branch: 'origin/main',
+      gitTags: false,
+      ignorePatterns: [
+        '*.test.*',
+        '.*/**',
+        '__snapshots__/',
+        'dist/',
+        'node_modules/',
+      ],
+    })
 
     const file = new TextFile(this, 'beachball.config.js', {
       readonly: true,
@@ -165,3 +162,5 @@ const getGitIgnoreOptions = ({
     ...(options.gitIgnoreOptions?.ignorePatterns ?? []),
   ],
 })
+
+const deepMerge = R.mergeDeepWith(R.concat)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -306,6 +306,9 @@ importers:
       beachball:
         specifier: 2.43.1
         version: 2.43.1(typescript@5.4.5)
+      ramda:
+        specifier: 0.29.1
+        version: 0.29.1
       typescript:
         specifier: ^5.0.0
         version: 5.4.5
@@ -316,6 +319,9 @@ importers:
       '@langri-sha/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
+      '@types/ramda':
+        specifier: 0.29.12
+        version: 0.29.12
       projen:
         specifier: 0.81.1
         version: 0.81.1(constructs@10.3.0)


### PR DESCRIPTION
Replace helper to avoid issues with breaking changes when projen adds
ESM support.
