### PR TITLE
Add `execa` to dependencies

### DIFF
--- a/change/@langri-sha-projen-lint-synthesized-db538617-90d6-419f-8523-99f61a60bfb4.json
+++ b/change/@langri-sha-projen-lint-synthesized-db538617-90d6-419f-8523-99f61a60bfb4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(lint-synthesized): Add `execa` to dependencies",
+  "packageName": "@langri-sha/projen-lint-synthesized",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-lint-synthesized/package.json
+++ b/packages/projen-lint-synthesized/package.json
@@ -9,13 +9,13 @@
   },
   "dependencies": {
     "debug": "4.3.4",
+    "execa": "8.0.1",
     "minimatch": "9.0.4"
   },
   "devDependencies": {
     "@langri-sha/jest-test": "workspace:*",
     "@langri-sha/tsconfig": "workspace:*",
     "@types/debug": "4.1.12",
-    "execa": "8.0.1",
     "prettier": "3.2.5",
     "projen": "0.81.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -307,6 +307,9 @@ importers:
       debug:
         specifier: 4.3.4
         version: 4.3.4
+      execa:
+        specifier: 8.0.1
+        version: 8.0.1
       minimatch:
         specifier: 9.0.4
         version: 9.0.4
@@ -323,9 +326,6 @@ importers:
       '@types/debug':
         specifier: 4.1.12
         version: 4.1.12
-      execa:
-        specifier: 8.0.1
-        version: 8.0.1
       prettier:
         specifier: 3.2.5
         version: 3.2.5


### PR DESCRIPTION
Add missing `execa` dependency to `@langri-sha/projen-lint-synthesized`.

Fixes #435.