### PR TITLE
Lint only package modules with projen

### DIFF
--- a/change/@langri-sha-projen-project-c2b7f01b-4335-40d0-800e-c9c3b399904f.json
+++ b/change/@langri-sha-projen-project-c2b7f01b-4335-40d0-800e-c9c3b399904f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(projen-project): Lint only package modules",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -195,8 +195,8 @@ export class Project extends BaseProject {
     new LintSynthesized(
       this,
       lintSynthesizedOptions ?? {
+        'package.json': 'pnpx sort-package-json',
         '*.{js,jsx,ts,tsx}': 'pnpm eslint --fix',
-        '*.json': 'pnpx sort-package-json',
         '*': 'pnpm prettier --write --ignore-unknown',
       },
     )


### PR DESCRIPTION
Lint only package modules for sorting, instead of all JSON modules.

Fixes #533.