### PR TITLE
Reconfigure TS unused vars

### DIFF
--- a/change/@langri-sha-babel-test-c2f12531-6782-40d6-8c0b-fbfa9bf07540.json
+++ b/change/@langri-sha-babel-test-c2f12531-6782-40d6-8c0b-fbfa9bf07540.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(eslint-config): Reconfigure TS unused vars",
+  "packageName": "@langri-sha/babel-test",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-eslint-config-b76f0682-3c62-4e48-8b4d-7c2eacc344e4.json
+++ b/change/@langri-sha-eslint-config-b76f0682-3c62-4e48-8b4d-7c2eacc344e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(eslint-config): Reconfigure TS unused vars",
+  "packageName": "@langri-sha/eslint-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-test/src/fixtures/babel-preset-test.ts
+++ b/packages/babel-test/src/fixtures/babel-preset-test.ts
@@ -1,7 +1,7 @@
 import type { ConfigAPI } from '@babel/core'
 
 const config = (
-  api: ConfigAPI,
+  _api: ConfigAPI,
   options: { foobar?: string },
 ): { plugins: Array<Array<unknown>> } => ({
   plugins: [

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -34,6 +34,19 @@ export default [
       ],
 
       // Contributing.
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          args: 'all',
+          argsIgnorePattern: '^_',
+          caughtErrors: 'all',
+          caughtErrorsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          ignoreRestSiblings: true,
+        },
+      ],
+
       'unicorn/no-anonymous-default-export': 'off',
       'unicorn/no-array-callback-reference': 'off',
       'unicorn/no-null': 'off',


### PR DESCRIPTION
Reconfigures rules to allow `_` prefixed args to be unused.