### PR TITLE
Correct configuration for projen custom Renovate manager

### DIFF
--- a/change/@langri-sha-projen-project-c133f340-223d-4f16-9187-ccfe640d903b.json
+++ b/change/@langri-sha-projen-project-c133f340-223d-4f16-9187-ccfe640d903b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(project): Correct Renovate dependency matching",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -571,7 +571,6 @@ node_modules/
         ],
         "matchStrings": [
           "\\.(?<depType>addDep|addDevDep|addPeerDep)\\('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
-          "'(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'",
         ],
       },
     ],

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -570,7 +570,7 @@ node_modules/
           "\\.?projen.*.(js|cjs|mjs|ts|mts|cts)$",
         ],
         "matchStrings": [
-          "\\.(?<depType>addDep|addDevDep|addPeerDep)('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
+          "\\.(?<depType>addDep|addDevDep|addPeerDep)\\('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
           "'(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'",
         ],
       },

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -565,7 +565,7 @@ node_modules/
       {
         "customType": "regex",
         "datasourceTemplate": "npm",
-        "depTypeTemplate": "{{#if (eq depType 'addDevDep')}}devDependencies{{else if (eq depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",
+        "depTypeTemplate": "{{#if (equals depType 'addDevDep')}}devDependencies{{else if (equals depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",
         "fileMatch": [
           "\\.?projen.*.(js|cjs|mjs|ts|mts|cts)$",
         ],

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -289,7 +289,6 @@ export class Project extends BaseProject {
           fileMatch: ['\\.?projen.*.(js|cjs|mjs|ts|mts|cts)$'],
           matchStrings: [
             "\\.(?<depType>addDep|addDevDep|addPeerDep)\\('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
-            "'(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'",
           ],
           depTypeTemplate:
             "{{#if (equals depType 'addDevDep')}}devDependencies{{else if (equals depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -292,7 +292,7 @@ export class Project extends BaseProject {
             "'(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'",
           ],
           depTypeTemplate:
-            "{{#if (eq depType 'addDevDep')}}devDependencies{{else if (eq depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",
+            "{{#if (equals depType 'addDevDep')}}devDependencies{{else if (equals depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",
         },
       ],
     }

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -288,7 +288,7 @@ export class Project extends BaseProject {
           datasourceTemplate: 'npm',
           fileMatch: ['\\.?projen.*.(js|cjs|mjs|ts|mts|cts)$'],
           matchStrings: [
-            "\\.(?<depType>addDep|addDevDep|addPeerDep)('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
+            "\\.(?<depType>addDep|addDevDep|addPeerDep)\\('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
             "'(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'",
           ],
           depTypeTemplate:

--- a/renovate.json5
+++ b/renovate.json5
@@ -11,8 +11,7 @@
       datasourceTemplate: 'npm',
       fileMatch: ['\\.?projen.*.(js|cjs|mjs|ts|mts|cts)$'],
       matchStrings: [
-        "\\.(?<depType>addDep|addDevDep|addPeerDep)('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
-        "'(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'",
+        "\\.(?<depType>addDep|addDevDep|addPeerDep)\\('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
       ],
       depTypeTemplate: "{{#if (equals depType 'addDevDep')}}devDependencies{{else if (equals depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,7 @@
         "\\.(?<depType>addDep|addDevDep|addPeerDep)('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
         "'(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'",
       ],
-      depTypeTemplate: "{{#if (eq depType 'addDevDep')}}devDependencies{{else if (eq depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",
+      depTypeTemplate: "{{#if (equals depType 'addDevDep')}}devDependencies{{else if (equals depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",
     },
   ],
 }


### PR DESCRIPTION
Fixes configuration for the Renovate custom manager that updates projen
dependencies, and removes loose dependency matching.

Fixes https://github.com/langri-sha/langri-sha.com/pull/544.