### PR TITLE
Transpile sources only for default task

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -5,7 +5,7 @@
       "description": "Synthesize project files",
       "steps": [
         {
-          "exec": "node --loader ts-node/esm .projenrc.mts"
+          "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts"
         }
       ]
     },

--- a/change/@langri-sha-projen-project-851124bb-e0d3-4199-888e-59e37732fd86.json
+++ b/change/@langri-sha-projen-project-851124bb-e0d3-4199-888e-59e37732fd86.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(project): Transpile sources only for default task",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -42,7 +42,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },
@@ -83,7 +83,7 @@ node_modules/
             "exec": "npx projen default",
           },
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },
@@ -146,7 +146,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },
@@ -242,7 +242,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },
@@ -373,7 +373,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },
@@ -454,7 +454,7 @@ lint-staged
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },
@@ -548,7 +548,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },
@@ -628,7 +628,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },
@@ -717,7 +717,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },
@@ -821,7 +821,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },
@@ -882,7 +882,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm .projenrc.mts",
+            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
           },
         ],
       },

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -195,7 +195,7 @@ export class Project extends BaseProject {
   #configureDefaultTask() {
     this.tasks
       .tryFind('default')
-      ?.exec(`node --loader ts-node/esm .projenrc.mts`)
+      ?.exec(`node --loader ts-node/esm/transpile-only .projenrc.mts`)
   }
 
   #configureEditorConfig({ editorConfigOptions }: ProjectOptions) {


### PR DESCRIPTION
Transpile sources only, when using `ts-node` for the default projen task.