### PR TITLE
Rewrite ESM imports with Jest

### DIFF
--- a/change/@langri-sha-jest-config-5d4405cc-083d-4033-99c5-c6395cce3830.json
+++ b/change/@langri-sha-jest-config-5d4405cc-083d-4033-99c5-c6395cce3830.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(jest-config): Rewrite ESM imports",
+  "packageName": "@langri-sha/jest-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -1,5 +1,9 @@
 import type { Config } from 'jest'
 
-const config: Config = {}
+const config: Config = {
+  moduleNameMapper: {
+    '^(\\.\\.?\\/.+)\\.jsx?$': '$1',
+  },
+}
 
 export default config


### PR DESCRIPTION
Add support for rewriting imports for ESM modules, without havinng to reconfigure TypeScript and Babel support.