### PR TITLE
Remove default tasks on subprojects

### DIFF
--- a/change/@langri-sha-projen-project-5342a8bf-1176-42f3-a977-2f599db1c470.json
+++ b/change/@langri-sha-projen-project-5342a8bf-1176-42f3-a977-2f599db1c470.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(project): Remove default tasks for subprojects",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -83,12 +83,6 @@ node_modules/
       "default": {
         "description": "Synthesize project files",
         "name": "default",
-        "steps": [
-          {
-            "cwd": "../../..",
-            "exec": "npx projen default",
-          },
-        ],
       },
       "test": {
         "description": "Run tests",

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -109,13 +109,13 @@ export class Project extends BaseProject {
     this.tasks.removeTask('pre-compile')
     this.tasks.removeTask('watch')
 
-    if (!this.parent) {
-      this.tasks.removeTask('install')
-      this.tasks.removeTask('install:ci')
-    }
-
     this.#configurePackage(options)
     this.#configureTypeScript(options)
+
+    if (this.parent) {
+      this.tasks.tryFind('install')?.reset()
+      this.tasks.tryFind('install:ci')?.reset()
+    }
 
     this.#configureBeachball(options)
     this.#configureCodeowners(options)

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -113,6 +113,7 @@ export class Project extends BaseProject {
     this.#configureTypeScript(options)
 
     if (this.parent) {
+      this.tasks.tryFind('default')?.reset()
       this.tasks.tryFind('install')?.reset()
       this.tasks.tryFind('install:ci')?.reset()
     }


### PR DESCRIPTION
Remove default tasks on subprojects, instead of incorrectly removing
them from the root project.

Fixes https://github.com/langri-sha/langri-sha.com/pull/540.