### PR TITLE
Correctly match projen source dependencies with renovate

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -42,7 +42,7 @@
     },
     {
       "name": "eslint",
-      "version": "9.2.0",
+      "version": "9.3.0",
       "type": "build"
     },
     {

--- a/.projenrc.mts
+++ b/.projenrc.mts
@@ -89,7 +89,7 @@ project.package?.addDevDeps(
   '@langri-sha/prettier@workspace:*',
   '@langri-sha/projen-project@workspace:*',
   '@langri-sha/tsconfig@workspace:*',
-  'eslint@9.2.0',
+  'eslint@9.3.0',
   'jest@29.7.0',
   'lint-staged@15.2.2',
   'prettier@3.2.5',

--- a/change/@langri-sha-projen-project-d6811f12-ac04-419d-8fb0-51b6a4caa92b.json
+++ b/change/@langri-sha-projen-project-d6811f12-ac04-419d-8fb0-51b6a4caa92b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(project): Update matching Renovate dependencies",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -592,13 +592,15 @@ node_modules/
       {
         "customType": "regex",
         "datasourceTemplate": "npm",
-        "depTypeTemplate": "{{#if (equals depType 'addDevDep')}}devDependencies{{else if (equals depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",
+        "depTypeTemplate": "{{#if (equals depType 'addDeps')}}dependencies{{else if (equals depType 'addDevDeps')}}devDependencies{{else}}peerDependencies{{/if}}",
         "fileMatch": [
           "\\.?projen.*.(js|cjs|mjs|ts|mts|cts)$",
         ],
         "matchStrings": [
-          "\\.(?<depType>addDep|addDevDep|addPeerDep)\\('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
+          "\\.(?<depType>addDeps|addDevDeps|addPeerDeps)\\([^)]*\\)",
+          "'(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'",
         ],
+        "matchStringsStrategy": "recursive",
       },
       {
         "customType": "regex",

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -293,11 +293,13 @@ export class Project extends BaseProject {
           customType: 'regex',
           datasourceTemplate: 'npm',
           fileMatch: ['\\.?projen.*.(js|cjs|mjs|ts|mts|cts)$'],
+          matchStringsStrategy: 'recursive',
           matchStrings: [
-            "\\.(?<depType>addDep|addDevDep|addPeerDep)\\('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
+            '\\.(?<depType>addDeps|addDevDeps|addPeerDeps)\\([^)]*\\)',
+            "'(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'",
           ],
           depTypeTemplate:
-            "{{#if (equals depType 'addDevDep')}}devDependencies{{else if (equals depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",
+            "{{#if (equals depType 'addDeps')}}dependencies{{else if (equals depType 'addDevDeps')}}devDependencies{{else}}peerDependencies{{/if}}",
         },
         {
           customType: 'regex',

--- a/renovate.json5
+++ b/renovate.json5
@@ -10,10 +10,12 @@
       customType: 'regex',
       datasourceTemplate: 'npm',
       fileMatch: ['\\.?projen.*.(js|cjs|mjs|ts|mts|cts)$'],
+      matchStringsStrategy: 'recursive',
       matchStrings: [
-        "\\.(?<depType>addDep|addDevDep|addPeerDep)\\('(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'\\)",
+        '\\.(?<depType>addDeps|addDevDeps|addPeerDeps)\\([^)]*\\)',
+        "'(?<depName>[a-zA-Z0-9-]+)@(?<currentValue>[^']+)'",
       ],
-      depTypeTemplate: "{{#if (equals depType 'addDevDep')}}devDependencies{{else if (equals depType 'addPeerDep')}}peerDependencies{{else}}dependencies{{/if}}",
+      depTypeTemplate: "{{#if (equals depType 'addDeps')}}dependencies{{else if (equals depType 'addDevDeps')}}devDependencies{{else}}peerDependencies{{/if}}",
     },
     {
       customType: 'regex',


### PR DESCRIPTION
Fixes issue with matching dependencies for projen modules with the
Renovate custom regex manager.

Fixes https://github.com/langri-sha/langri-sha.com/pull/548.