### PR TITLE
Ensure package always has version set

### DIFF
--- a/change/@langri-sha-projen-project-050e6b51-2978-4c68-916b-9a40a59e1ac8.json
+++ b/change/@langri-sha-projen-project-050e6b51-2978-4c68-916b-9a40a59e1ac8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(project): Ensure package always has version set",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -394,6 +394,7 @@ module.exports = {
     "scripts": {
       "default": "npx projen default",
     },
+    "version": "0.0.0",
   },
   "prettier.config.mjs": "import defaults from '@langri-sha/prettier'
 
@@ -527,6 +528,7 @@ export default [...defaults, {"ignores":[".*",".projenrc.mts"]}]",
     "scripts": {
       "default": "npx projen default",
     },
+    "version": "0.0.0",
   },
 }
 `;
@@ -746,6 +748,7 @@ lint-staged
       "default": "npx projen default",
       "prepare": "husky",
     },
+    "version": "0.0.0",
   },
 }
 `;
@@ -1218,6 +1221,7 @@ node_modules/
     "scripts": {
       "default": "npx projen default",
     },
+    "version": "0.0.0",
   },
   "tsconfig.json": {
     "$schema": "https://json.schemastore.org/tsconfig",
@@ -1369,6 +1373,7 @@ exports[`with package defaults 1`] = `
   "scripts": {
     "default": "npx projen default",
   },
+  "version": "0.0.0",
 }
 `;
 

--- a/packages/projen-project/src/lib/node-package.ts
+++ b/packages/projen-project/src/lib/node-package.ts
@@ -13,14 +13,14 @@ export class NodePackage extends javascript.NodePackage {
   constructor(project: Project, options?: NodePackageOptions) {
     super(project, options)
 
-    this.addVersion(this.#getPackageJson().version)
+    this.addVersion(this.#getPackageJson()?.version ?? '0.0.0')
   }
 
   #getPackageJson() {
     try {
       return JSON.parse(fs.readFileSync(this.file.absolutePath, 'utf-8'))
     } catch (_) {
-      return '0.0.0'
+      return undefined
     }
   }
 }


### PR DESCRIPTION
Ensures package always has version set, which defaults to `0.0.0`.

Fixes #574.