### PR TITLE
Run `lint-synthesized` on all subprojects

### DIFF
--- a/.projenrc.mts
+++ b/.projenrc.mts
@@ -59,6 +59,7 @@ const project = new Project({
     },
   },
   lintStaged: {},
+  lintSynthesized: {},
   prettier: {
     ignorePatterns: ['*.frag'],
   },

--- a/change/@langri-sha-projen-lint-synthesized-d49eb479-d2ab-421b-a4ac-10f7e0738ffd.json
+++ b/change/@langri-sha-projen-lint-synthesized-d49eb479-d2ab-421b-a4ac-10f7e0738ffd.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(lint-synthesized): Run on all projects",
+  "packageName": "@langri-sha/projen-lint-synthesized",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-project-400ab783-8044-4f61-a5ea-6ebf51c13dd5.json
+++ b/change/@langri-sha-projen-project-400ab783-8044-4f61-a5ea-6ebf51c13dd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(lint-synthesized): Run on all projects",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-lint-synthesized/src/index.test.ts
+++ b/packages/projen-lint-synthesized/src/index.test.ts
@@ -41,12 +41,21 @@ test('lints synthesized files', async () => {
     '*': 'prettier --ignore-unknown --write',
   })
 
+  const project2 = new Project({
+    name: 'test-project2',
+    outdir: 'project2',
+    parent: project,
+  })
+
   let file, contents
 
   file = new TextFile(project, 'test1.js')
   file.addLine(`module.exports = ${JSON.stringify({ foo: 'bar' })}`)
 
   file = new TextFile(project, 'test2.js')
+  file.addLine(`module.exports = ${JSON.stringify({ foo: 'bar' })}`)
+
+  file = new TextFile(project2, 'test3.js')
   file.addLine(`module.exports = ${JSON.stringify({ foo: 'bar' })}`)
 
   project.synth()
@@ -60,6 +69,9 @@ test('lints synthesized files', async () => {
   contents = file.toString('utf8')
 
   expect(contents).toEqual(`module.exports = { foo: "bar" };\n`)
+
+  file = await fs.readFile(path.join(project.outdir, 'project2', 'test3.js'))
+  contents = file.toString('utf8')
 })
 
 test('lints hidden synthesized files', async () => {

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -356,17 +356,14 @@ export class Project extends BaseProject {
     )
   }
 
-  #configureLintSynthesized({
-    lintSynthesized: lintSynthesizedOptions,
-  }: ProjectOptions) {
-    new LintSynthesized(
-      this,
-      lintSynthesizedOptions ?? {
-        'package.json': 'pnpx sort-package-json',
-        '*.{js,jsx,ts,tsx}': 'pnpm eslint --fix',
-        '*': 'pnpm prettier --write --ignore-unknown',
-      },
-    )
+  #configureLintSynthesized({ lintSynthesized }: ProjectOptions) {
+    const defaults: LintSynthesizedOptions = {
+      'package.json': 'pnpx sort-package-json',
+      '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}': 'pnpm eslint --fix',
+      '*': 'pnpm prettier --write --ignore-unknown',
+    }
+
+    new LintSynthesized(this, deepMerge(defaults, lintSynthesized))
   }
 
   #configureNpmIgnore({

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -357,6 +357,10 @@ export class Project extends BaseProject {
   }
 
   #configureLintSynthesized({ lintSynthesized }: ProjectOptions) {
+    if (!lintSynthesized) {
+      return
+    }
+
     const defaults: LintSynthesizedOptions = {
       'package.json': 'pnpx sort-package-json',
       '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}': 'pnpm eslint --fix',


### PR DESCRIPTION
Instead of just the current project, will check files of all subprojects
as well when linting files.
