### PR TITLE
Omit Node.js engine package defaults

### DIFF
--- a/.projenrc.mts
+++ b/.projenrc.mts
@@ -23,6 +23,7 @@ const project = new Project({
     repository: 'langri-sha/langri-sha.com',
     bugsUrl: 'https://github.com/langri-sha/langri-sha.com/issues',
     homepage: 'https://langri-sha.com',
+    minNodeVersion: '20.12.0',
   },
   beachball: {},
   codeowners: {

--- a/change/@langri-sha-projen-beachball-cc328bdd-d822-4293-a836-e88231b1cb88.json
+++ b/change/@langri-sha-projen-beachball-cc328bdd-d822-4293-a836-e88231b1cb88.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-beachball",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-codeowners-85aee328-557a-4ce9-b7fc-d0cc515aaf25.json
+++ b/change/@langri-sha-projen-codeowners-85aee328-557a-4ce9-b7fc-d0cc515aaf25.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-codeowners",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-editorconfig-3c880a85-a198-4c57-901e-cacfa1372e75.json
+++ b/change/@langri-sha-projen-editorconfig-3c880a85-a198-4c57-901e-cacfa1372e75.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-editorconfig",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-eslint-fea0dcbc-db81-4dce-96f8-2c7a1cc2ef50.json
+++ b/change/@langri-sha-projen-eslint-fea0dcbc-db81-4dce-96f8-2c7a1cc2ef50.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-eslint",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-husky-313538b4-8f7f-4a07-8b5c-ea2c6e33f214.json
+++ b/change/@langri-sha-projen-husky-313538b4-8f7f-4a07-8b5c-ea2c6e33f214.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-husky",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-jest-config-a6f8962a-d72b-4ce0-ad88-9910dca56763.json
+++ b/change/@langri-sha-projen-jest-config-a6f8962a-d72b-4ce0-ad88-9910dca56763.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-jest-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-license-19c2c9a1-8b61-4e32-8218-cca5eac38010.json
+++ b/change/@langri-sha-projen-license-19c2c9a1-8b61-4e32-8218-cca5eac38010.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-license",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-lint-staged-7e42940d-56fc-4333-8aff-eab34c3465cf.json
+++ b/change/@langri-sha-projen-lint-staged-7e42940d-56fc-4333-8aff-eab34c3465cf.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-lint-staged",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-lint-synthesized-c7286f74-7538-4138-9f14-a2d658ec7b6e.json
+++ b/change/@langri-sha-projen-lint-synthesized-c7286f74-7538-4138-9f14-a2d658ec7b6e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-lint-synthesized",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-prettier-86836d28-18be-48fb-9e00-6b9b6ff80f3a.json
+++ b/change/@langri-sha-projen-prettier-86836d28-18be-48fb-9e00-6b9b6ff80f3a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-prettier",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-project-c83dadc8-1370-4289-8919-b31c15a426f7.json
+++ b/change/@langri-sha-projen-project-c83dadc8-1370-4289-8919-b31c15a426f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-renovate-b0c6d3e2-ca4b-491f-8430-f86c465d2e3c.json
+++ b/change/@langri-sha-projen-renovate-b0c6d3e2-ca4b-491f-8430-f86c465d2e3c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-renovate",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-typescript-config-d749b804-1187-4a3d-a825-0845e88bbc9d.json
+++ b/change/@langri-sha-projen-typescript-config-d749b804-1187-4a3d-a825-0845e88bbc9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/projen-typescript-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-webpack-5a69d91f-8951-4e23-94e2-350bca37a901.json
+++ b/change/@langri-sha-webpack-5a69d91f-8951-4e23-94e2-350bca37a901.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Omit Node.js engine package defaults",
+  "packageName": "@langri-sha/webpack",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-beachball/package.json
+++ b/packages/projen-beachball/package.json
@@ -23,9 +23,6 @@
     "beachball": "^2.0.0",
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-codeowners/package.json
+++ b/packages/projen-codeowners/package.json
@@ -21,9 +21,6 @@
   "peerDependencies": {
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-editorconfig/package.json
+++ b/packages/projen-editorconfig/package.json
@@ -21,9 +21,6 @@
   "peerDependencies": {
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-eslint/package.json
+++ b/packages/projen-eslint/package.json
@@ -27,9 +27,6 @@
     "eslint": "^9.0.0",
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-husky/package.json
+++ b/packages/projen-husky/package.json
@@ -24,9 +24,6 @@
     "husky": "^9.0.1",
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-jest-config/package.json
+++ b/packages/projen-jest-config/package.json
@@ -27,9 +27,6 @@
     "jest": "^28.00 || ^29.00",
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-license/package.json
+++ b/packages/projen-license/package.json
@@ -24,9 +24,6 @@
   "peerDependencies": {
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-lint-staged/package.json
+++ b/packages/projen-lint-staged/package.json
@@ -27,9 +27,6 @@
     "lint-staged": "^15.0.0",
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-lint-synthesized/package.json
+++ b/packages/projen-lint-synthesized/package.json
@@ -28,9 +28,6 @@
   "peerDependencies": {
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-prettier/package.json
+++ b/packages/projen-prettier/package.json
@@ -27,9 +27,6 @@
     "prettier": "^3.0.0",
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -384,9 +384,6 @@ module.exports = {
       "ts-node": "10.9.2",
       "typescript": "5.4.5",
     },
-    "engines": {
-      "node": ">= 20.12.0",
-    },
     "license": "Apache-2.0",
     "main": "src/index.ts",
     "name": "test-project",
@@ -517,9 +514,6 @@ export default [...defaults, {"ignores":[".*",".projenrc.mts"]}]",
     "devDependencies": {
       "@langri-sha/projen-project": "*",
       "projen": "0.81.15",
-    },
-    "engines": {
-      "node": ">= 20.12.0",
     },
     "license": "Apache-2.0",
     "main": "src/index.ts",
@@ -737,9 +731,6 @@ lint-staged
       "@langri-sha/projen-project": "*",
       "husky": "9.0.11",
       "projen": "0.81.15",
-    },
-    "engines": {
-      "node": ">= 20.12.0",
     },
     "license": "Apache-2.0",
     "main": "src/index.ts",
@@ -1210,9 +1201,6 @@ node_modules/
       "ts-node": "10.9.2",
       "typescript": "5.4.5",
     },
-    "engines": {
-      "node": ">= 20.12.0",
-    },
     "license": "Apache-2.0",
     "main": "src/index.ts",
     "name": "test-project",
@@ -1361,9 +1349,6 @@ exports[`with package defaults 1`] = `
   "devDependencies": {
     "@langri-sha/projen-project": "*",
     "projen": "0.81.15",
-  },
-  "engines": {
-    "node": ">= 20.12.0",
   },
   "license": "Apache-2.0",
   "main": "src/index.ts",

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -402,7 +402,6 @@ export class Project extends BaseProject {
     const defaults: NodePackageOptions = {
       entrypoint: 'src/index.ts',
       packageManager: javascript.NodePackageManager.PNPM,
-      minNodeVersion: '20.12.0',
     }
 
     this.package = new NodePackage(this, deepMerge(defaults, pkg))

--- a/packages/projen-renovate/package.json
+++ b/packages/projen-renovate/package.json
@@ -24,9 +24,6 @@
   "peerDependencies": {
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/projen-typescript-config/package.json
+++ b/packages/projen-typescript-config/package.json
@@ -25,9 +25,6 @@
   "peerDependencies": {
     "projen": "^0.81.15"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -30,9 +30,6 @@
     "@babel/register": "^7.0.0",
     "webpack": "^5.0.0"
   },
-  "engines": {
-    "node": ">= 20.12.0"
-  },
   "publishConfig": {
     "access": "public",
     "main": "lib/index.js",


### PR DESCRIPTION
Skip setting Node.js engine versions for packages, and let each package configure things itself.