### PR TITLE
Reset projen install task for automation

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -23,7 +23,7 @@
       "description": "Install project dependencies using frozen lockfile",
       "steps": [
         {
-          "exec": "pnpm i --frozen-lockfile"
+          "exec": "pnpm i --no-frozen-lockfile"
         }
       ]
     },

--- a/change/@langri-sha-projen-project-8531d1e4-6732-4286-84f4-2e321b4bc4b6.json
+++ b/change/@langri-sha-projen-project-8531d1e4-6732-4286-84f4-2e321b4bc4b6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(projen): Reset `install:ci` task",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -346,7 +346,7 @@ CHANGELOG.md
         "name": "install:ci",
         "steps": [
           {
-            "exec": "pnpm i --frozen-lockfile",
+            "exec": "pnpm i --no-frozen-lockfile",
           },
         ],
       },
@@ -490,7 +490,7 @@ node_modules/
         "name": "install:ci",
         "steps": [
           {
-            "exec": "pnpm i --frozen-lockfile",
+            "exec": "pnpm i --no-frozen-lockfile",
           },
         ],
       },
@@ -709,7 +709,7 @@ lint-staged
         "name": "install:ci",
         "steps": [
           {
-            "exec": "pnpm i --frozen-lockfile",
+            "exec": "pnpm i --no-frozen-lockfile",
           },
         ],
       },
@@ -1198,7 +1198,7 @@ node_modules/
         "name": "install:ci",
         "steps": [
           {
-            "exec": "pnpm i --frozen-lockfile",
+            "exec": "pnpm i --no-frozen-lockfile",
           },
         ],
       },

--- a/packages/projen-project/src/lib/__snapshots__/node-package.test.ts.snap
+++ b/packages/projen-project/src/lib/__snapshots__/node-package.test.ts.snap
@@ -154,7 +154,7 @@ node_modules/
         "name": "install:ci",
         "steps": [
           {
-            "exec": "yarn install --check-files --frozen-lockfile",
+            "exec": "yarn install --check-files",
           },
         ],
       },

--- a/packages/projen-project/src/lib/node-package.ts
+++ b/packages/projen-project/src/lib/node-package.ts
@@ -20,6 +20,11 @@ export class NodePackage extends javascript.NodePackage {
     if (options?.type) {
       this.addField('type', options.type)
     }
+
+    // Reset, so we can run `pnpx projen` on CI after Renovate upgrades.
+    this.project.tasks
+      .tryFind('install:ci')
+      ?.reset(this.project.tasks.tryFind('install')?.steps[0]?.exec)
   }
 
   #getPackageJson() {


### PR DESCRIPTION
Resets task, so we can use automation to run `pnpx projen` on CI.