### PR TITLE
Dedupe TypeScript project references

### DIFF
--- a/change/@langri-sha-projen-typescript-config-7a1ac588-d4c9-42f5-b169-31cec2dba180.json
+++ b/change/@langri-sha-projen-typescript-config-7a1ac588-d4c9-42f5-b169-31cec2dba180.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(typescript-config): Dedupe references",
+  "packageName": "@langri-sha/projen-typescript-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-typescript-config/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-typescript-config/src/__snapshots__/index.test.ts.snap
@@ -38,6 +38,17 @@ exports[`add reference 1`] = `
 }
 `;
 
+exports[`dedupes references 1`] = `
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "references": [
+    {
+      "path": "a",
+    },
+  ],
+}
+`;
+
 exports[`defaults 1`] = `
 {
   "$schema": "https://json.schemastore.org/tsconfig",

--- a/packages/projen-typescript-config/src/index.test.ts
+++ b/packages/projen-typescript-config/src/index.test.ts
@@ -88,3 +88,17 @@ test('sorts references', () => {
   project.synth()
   expect(synthSnapshot(project)['tsconfig.json']).toMatchSnapshot()
 })
+
+test('dedupes references', () => {
+  const project = new Project({
+    name: 'test-project',
+  })
+
+  const conf = new TypeScriptConfig(project, {})
+  conf.addReference('a')
+  conf.addReference('a')
+  conf.addReference('a')
+
+  project.synth()
+  expect(synthSnapshot(project)['tsconfig.json']).toMatchSnapshot()
+})

--- a/packages/projen-typescript-config/src/index.ts
+++ b/packages/projen-typescript-config/src/index.ts
@@ -51,7 +51,21 @@ export class TypeScriptConfig extends JsonFile {
       matched,
     ) as Required<TypeScriptConfigOptions>['config']
 
-    config.references?.sort((a, b) => a.path.localeCompare(b.path))
+    if (config.references) {
+      config.references.sort((a, b) => a.path.localeCompare(b.path))
+
+      const deduped = Object.values(
+        config.references.reduce(
+          (acc, item) => {
+            acc[item.path] = item
+            return acc
+          },
+          {} as Record<string, { path: string }>,
+        ),
+      )
+
+      config.references = deduped
+    }
 
     const json = JSON.stringify(config, null, 2)
 


### PR DESCRIPTION
Dedupes TypeScript project references from configs.