### PR TITLE
Always run workspace jobs

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   post-upgrade:
+    name: Renovate Post-Upgrade
     runs-on: ubuntu-latest
 
     if: ${{ github.actor == 'renovate[bot]' || github.actor == 'dependabot[bot]' }}
@@ -60,6 +61,7 @@ jobs:
           path: .diff.patch
 
   commit-upgrade-changes:
+    name: Commit Upgrade Changes
     runs-on: ubuntu-latest
     if: ${{ needs.post-upgrade.outputs.has-changes }}
     needs: [post-upgrade]

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -94,6 +94,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     needs: [commit-upgrade-changes]
+    if: always()
 
     steps:
       - name: Checkout

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -155,6 +155,7 @@ jobs:
     name: Jest
     runs-on: ubuntu-latest
     needs: [commit-upgrade-changes]
+    if: always()
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Always run workspace jobs, even if the Renovate post-upgrade job was
skipped.
