### PR TITLE
Add Git status to porcelain checks

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -136,6 +136,7 @@ jobs:
 
           if [[ $(git status --porcelain) ]]; then
             echo '::error::Some packages need fixing.'
+            git status
             git diff
             exit 1
           fi


### PR DESCRIPTION
Run Git status as part of doing porcelain checks.