### PR TITLE
Use workspace `@langri-sha/tsconfig` package

### DIFF
--- a/.projenrc.mts
+++ b/.projenrc.mts
@@ -95,6 +95,12 @@ const subproject = (project: Project) => {
   })
 
   project.tryRemoveFile('.gitignore')
+
+  if (project.name !== '@langri-sha/tsconfig') {
+    project
+      .tryFindObjectFile('package.json')
+      ?.addOverride('devDependencies.@langri-sha/tsconfig', 'workspace:*')
+  }
 }
 
 const test = (project: Project) => {

--- a/change/@langri-sha-projen-babel-09c0d1df-9721-4643-ad61-2bc50b41cec0.json
+++ b/change/@langri-sha-projen-babel-09c0d1df-9721-4643-ad61-2bc50b41cec0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(projen): Use workspace `@langri-sha/tsconfig`",
+  "packageName": "@langri-sha/projen-babel",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-pnpm-workspace-8afd6794-0bee-42ba-a8b3-281060b448e0.json
+++ b/change/@langri-sha-projen-pnpm-workspace-8afd6794-0bee-42ba-a8b3-281060b448e0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(projen): Use workspace `@langri-sha/tsconfig`",
+  "packageName": "@langri-sha/projen-pnpm-workspace",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-schemastore-to-typescript-5cd5a92a-fcb3-43db-ab1b-0a261427bdeb.json
+++ b/change/@langri-sha-schemastore-to-typescript-5cd5a92a-fcb3-43db-ab1b-0a261427bdeb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(projen): Use workspace `@langri-sha/tsconfig`",
+  "packageName": "@langri-sha/schemastore-to-typescript",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-vitest-fbf8c2cb-7775-42dc-b578-286ff4df1203.json
+++ b/change/@langri-sha-vitest-fbf8c2cb-7775-42dc-b578-286ff4df1203.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(projen): Use workspace `@langri-sha/tsconfig`",
+  "packageName": "@langri-sha/vitest",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-babel/package.json
+++ b/packages/projen-babel/package.json
@@ -17,7 +17,7 @@
     "serialize-javascript": "6.0.2"
   },
   "devDependencies": {
-    "@langri-sha/tsconfig": "*",
+    "@langri-sha/tsconfig": "workspace:*",
     "@langri-sha/vitest": "workspace:*",
     "@types/serialize-javascript": "5.0.4"
   },

--- a/packages/projen-pnpm-workspace/package.json
+++ b/packages/projen-pnpm-workspace/package.json
@@ -17,7 +17,7 @@
     "yaml": "2.4.5"
   },
   "devDependencies": {
-    "@langri-sha/tsconfig": "*",
+    "@langri-sha/tsconfig": "workspace:*",
     "@langri-sha/vitest": "workspace:*"
   },
   "peerDependencies": {

--- a/packages/schemastore-to-typescript/package.json
+++ b/packages/schemastore-to-typescript/package.json
@@ -27,7 +27,7 @@
     "keyv-file": "0.3.1"
   },
   "devDependencies": {
-    "@langri-sha/tsconfig": "*",
+    "@langri-sha/tsconfig": "workspace:*",
     "@langri-sha/vitest": "workspace:*",
     "@types/debug": "4.1.12"
   },

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -18,7 +18,7 @@
     "tempy": "1.0.1"
   },
   "devDependencies": {
-    "@langri-sha/tsconfig": "*"
+    "@langri-sha/tsconfig": "workspace:*"
   },
   "peerDependencies": {
     "vitest": "^1.6.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,8 +311,8 @@ importers:
         version: 6.0.2
     devDependencies:
       '@langri-sha/tsconfig':
-        specifier: '*'
-        version: 0.9.0(typescript@5.5.3)
+        specifier: workspace:*
+        version: link:../tsconfig
       '@langri-sha/vitest':
         specifier: workspace:*
         version: link:../vitest
@@ -501,8 +501,8 @@ importers:
         version: 2.4.5
     devDependencies:
       '@langri-sha/tsconfig':
-        specifier: '*'
-        version: 0.9.0(typescript@5.5.3)
+        specifier: workspace:*
+        version: link:../tsconfig
       '@langri-sha/vitest':
         specifier: workspace:*
         version: link:../vitest
@@ -686,8 +686,8 @@ importers:
         version: 0.82.4(constructs@10.3.0)
     devDependencies:
       '@langri-sha/tsconfig':
-        specifier: '*'
-        version: 0.9.0(typescript@5.5.3)
+        specifier: workspace:*
+        version: link:../tsconfig
       '@langri-sha/vitest':
         specifier: workspace:*
         version: link:../vitest
@@ -714,8 +714,8 @@ importers:
         version: 1.6.0(@types/node@20.14.9)(terser@5.30.0)
     devDependencies:
       '@langri-sha/tsconfig':
-        specifier: '*'
-        version: 0.9.0(typescript@5.5.3)
+        specifier: workspace:*
+        version: link:../tsconfig
 
   packages/webpack:
     dependencies:
@@ -2246,11 +2246,6 @@ packages:
 
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
-
-  '@langri-sha/tsconfig@0.9.0':
-    resolution: {integrity: sha512-YFHwApAiT/RGQFkmw02BZSVmvxqaQu7LVn/Sihm42f6jvC7aB9HSoDZNt1FNlIHmnLtntaW8MObCM4N9cg9tGg==}
-    peerDependencies:
-      typescript: ^5.0.0
 
   '@leichtgewicht/ip-codec@2.0.4':
     resolution: {integrity: sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==}
@@ -10512,10 +10507,6 @@ snapshots:
       - supports-color
 
   '@kwsites/promise-deferred@1.1.1': {}
-
-  '@langri-sha/tsconfig@0.9.0(typescript@5.5.3)':
-    dependencies:
-      typescript: 5.5.3
 
   '@leichtgewicht/ip-codec@2.0.4': {}
 


### PR DESCRIPTION
Fixes issue with subprojects depending on latest
`@langris-sha/tsconfig`, instead of the one installed in the workspace.