### PR TITLE
Remove manual Babel entry from TS files list

### DIFF
--- a/.projenrc.mts
+++ b/.projenrc.mts
@@ -77,7 +77,6 @@ const project = new Project({
   swcrc: {},
   typeScriptConfig: {
     config: {
-      files: ['babel.config.js'],
       references: [{ path: './apps/web' }],
     },
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,14 +2,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@langri-sha/tsconfig",
-  "files": [
-    ".projenrc.mts",
-    "babel.config.js",
-    "beachball.config.js",
-    "eslint.config.mjs",
-    "lint-staged.config.mjs",
-    "prettier.config.mjs"
-  ],
   "references": [
     {
       "path": "./apps/web"
@@ -95,5 +87,13 @@
     {
       "path": "packages/webpack"
     }
+  ],
+  "files": [
+    ".projenrc.mts",
+    "babel.config.js",
+    "beachball.config.js",
+    "eslint.config.mjs",
+    "lint-staged.config.mjs",
+    "prettier.config.mjs"
   ]
 }


### PR DESCRIPTION
Removes manual entry for the Babel configuration from the TS files list.

Fixes #638.