### PR TITLE
Add missing `eslint-config-prettier`

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -220,6 +220,7 @@ project.addSubproject(
       entrypoint: 'src/index.js',
       deps: [
         '@eslint/js@9.7.0',
+        'eslint-config-prettier@9.1.0',
         'eslint-plugin-jsdoc@48.7.0',
         'eslint-plugin-prettier@5.1.3',
         'eslint-plugin-unicorn@54.0.0',

--- a/change/@langri-sha-eslint-config-00636242-a9bd-43f4-9e0f-3230bfa1e96e.json
+++ b/change/@langri-sha-eslint-config-00636242-a9bd-43f4-9e0f-3230bfa1e96e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(eslint-config): Add missing `eslint-config-prettier`",
+  "packageName": "@langri-sha/eslint-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config/.projen/deps.json
+++ b/packages/eslint-config/.projen/deps.json
@@ -21,6 +21,11 @@
       "type": "runtime"
     },
     {
+      "name": "eslint-config-prettier",
+      "version": "9.1.0",
+      "type": "runtime"
+    },
+    {
       "name": "eslint-plugin-jsdoc",
       "version": "48.7.0",
       "type": "runtime"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -20,6 +20,7 @@
   "scripts": {},
   "dependencies": {
     "@eslint/js": "9.7.0",
+    "eslint-config-prettier": "9.1.0",
     "eslint-plugin-jsdoc": "48.7.0",
     "eslint-plugin-prettier": "5.1.3",
     "eslint-plugin-unicorn": "54.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -213,6 +213,9 @@ importers:
       eslint:
         specifier: ^9.0.0
         version: 9.5.0
+      eslint-config-prettier:
+        specifier: 9.1.0
+        version: 9.1.0(eslint@9.5.0)
       eslint-plugin-jsdoc:
         specifier: 48.7.0
         version: 48.7.0(eslint@9.5.0)
@@ -9585,7 +9588,6 @@ snapshots:
   eslint-config-prettier@9.1.0(eslint@9.5.0):
     dependencies:
       eslint: 9.5.0
-    optional: true
 
   eslint-plugin-jsdoc@48.7.0(eslint@9.5.0):
     dependencies:


### PR DESCRIPTION
Restores required peer dependency `eslint-config-prettier` for `eslint-plugin-prettier`.

Fixes #498.