### PR TITLE
Harden Projen component types

### DIFF
--- a/change/@langri-sha-projen-babel-667c6055-bb69-4762-bbaa-bd349619d1f2.json
+++ b/change/@langri-sha-projen-babel-667c6055-bb69-4762-bbaa-bd349619d1f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-babel",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-beachball-4dedbb35-8776-48b6-8585-74389569df27.json
+++ b/change/@langri-sha-projen-beachball-4dedbb35-8776-48b6-8585-74389569df27.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-beachball",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-codeowners-0e4a812d-496e-4f42-989b-1dcfcb027088.json
+++ b/change/@langri-sha-projen-codeowners-0e4a812d-496e-4f42-989b-1dcfcb027088.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-codeowners",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-editorconfig-6bd53ad6-5d71-421f-bca5-a4096934c7c3.json
+++ b/change/@langri-sha-projen-editorconfig-6bd53ad6-5d71-421f-bca5-a4096934c7c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-editorconfig",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-eslint-f97eda7b-5bca-4a5e-a471-a6425f364f9d.json
+++ b/change/@langri-sha-projen-eslint-f97eda7b-5bca-4a5e-a471-a6425f364f9d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-eslint",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-jest-config-e72dddec-b19a-4058-ba11-ae0c06b84b4e.json
+++ b/change/@langri-sha-projen-jest-config-e72dddec-b19a-4058-ba11-ae0c06b84b4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-jest-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-lint-staged-f52d5cbe-fd10-49fd-aca1-eb948e4c385f.json
+++ b/change/@langri-sha-projen-lint-staged-f52d5cbe-fd10-49fd-aca1-eb948e4c385f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-lint-staged",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-lint-synthesized-e1f3dc81-0a8a-4203-9177-c33f91fede8f.json
+++ b/change/@langri-sha-projen-lint-synthesized-e1f3dc81-0a8a-4203-9177-c33f91fede8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-lint-synthesized",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-pnpm-workspace-0124a94e-a885-4a4f-ba1c-29106ba9713c.json
+++ b/change/@langri-sha-projen-pnpm-workspace-0124a94e-a885-4a4f-ba1c-29106ba9713c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-pnpm-workspace",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-prettier-fe772e51-b3e4-4c6b-bb6f-2312f4e61492.json
+++ b/change/@langri-sha-projen-prettier-fe772e51-b3e4-4c6b-bb6f-2312f4e61492.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-prettier",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-project-81c6352b-5d3f-41e9-a2fe-9ce07c06de77.json
+++ b/change/@langri-sha-projen-project-81c6352b-5d3f-41e9-a2fe-9ce07c06de77.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-readme-1e477e84-128d-4070-b25b-9a649ce00465.json
+++ b/change/@langri-sha-projen-readme-1e477e84-128d-4070-b25b-9a649ce00465.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-readme",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-typescript-config-9362a198-cac3-4a01-98a5-05aaeeec68fe.json
+++ b/change/@langri-sha-projen-typescript-config-9362a198-cac3-4a01-98a5-05aaeeec68fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(workspace): Harden Projen component types",
+  "packageName": "@langri-sha/projen-typescript-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-babel/src/index.ts
+++ b/packages/projen-babel/src/index.ts
@@ -11,17 +11,17 @@ export interface BabelOptions {
    *
    * @default 'babel.config.js'
    */
-  filename?: string
+  readonly filename?: string
 
   /**
    * Whether to output a config function, and the code to be executed.
    */
-  configApiFunction?: string
+  readonly configApiFunction?: string
 
   /**
    * Options for transforming Babel.
    */
-  options?: TransformOptions
+  readonly options?: TransformOptions
 }
 
 export class Babel extends FileBase {

--- a/packages/projen-beachball/src/index.ts
+++ b/packages/projen-beachball/src/index.ts
@@ -5,8 +5,8 @@ import { Project, TextFile } from 'projen'
  * Options for configuring Beachball.
  */
 export interface BeachballOptions {
-  filename?: string
-  config?: BeachballConfig
+  readonly filename?: string
+  readonly config?: BeachballConfig
 }
 
 export class Beachball extends TextFile {

--- a/packages/projen-codeowners/src/index.ts
+++ b/packages/projen-codeowners/src/index.ts
@@ -4,7 +4,7 @@ import { Component, type Project, TextFile } from 'projen'
  * Codeowners options.
  */
 export interface CodeownersOptions {
-  [pattern: string]: string | string[]
+  readonly [pattern: string]: string | string[]
 }
 
 /**

--- a/packages/projen-editorconfig/src/index.ts
+++ b/packages/projen-editorconfig/src/index.ts
@@ -4,43 +4,48 @@ import { Component, IniFile, type Project } from 'projen'
  * EditorConfig options.
  */
 export interface EditorConfigOptions {
-  [pattern: string]: {
+  readonly [pattern: string]: {
     /**
      * Enforce either spaces or tabs for indentation.
      */
-    indent_style?: 'tab' | 'space'
+    readonly indent_style?: 'tab' | 'space'
 
     /**
      * The number of spaces per indent level OR the string "tab" to use the editor's tab settings.
      */
-    indent_size?: number | 'tab'
+    readonly indent_size?: number | 'tab'
 
     /**
      * The number of spaces a tab represents (overrides the editor's setting if indent_style is 'tab').
      */
-    tab_width?: number
+    readonly tab_width?: number
 
     /**
      * Specifies the line ending format (LF, CRLF, or CR).
      */
-    end_of_line?: 'lf' | 'crlf' | 'cr'
+    readonly end_of_line?: 'lf' | 'crlf' | 'cr'
 
     /**
      * Specifies the encoding of the file.
      */
 
-    charset?: 'latin1' | 'utf-8' | 'utf-8-bom' | 'utf-16be' | 'utf-16le'
+    readonly charset?:
+      | 'latin1'
+      | 'utf-8'
+      | 'utf-8-bom'
+      | 'utf-16be'
+      | 'utf-16le'
 
     /**
      * Trims any whitespace at the end of lines.
      * @default true
      */
-    trim_trailing_whitespace?: boolean
+    readonly trim_trailing_whitespace?: boolean
 
     /**
      * Ensures a single newline at the end of the file.
      */
-    insert_final_newline?: boolean
+    readonly insert_final_newline?: boolean
   }
 }
 

--- a/packages/projen-eslint/src/index.ts
+++ b/packages/projen-eslint/src/index.ts
@@ -10,23 +10,23 @@ export interface ESLintOptions {
    *
    * @default 'eslint.config.js'
    */
-  filename?: string
+  readonly filename?: string
 
   /**
    * Name of the ESLint configuration package to extend from.
    */
-  extends?: string
+  readonly extends?: string
 
   /**
    * Ignore patterns.
    */
-  ignorePatterns?: string[]
+  readonly ignorePatterns?: string[]
 
   /**
    * Prettier configuration object.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  config?: any[]
+  readonly config?: any[]
 }
 
 export class ESLint extends FileBase {

--- a/packages/projen-jest-config/src/index.ts
+++ b/packages/projen-jest-config/src/index.ts
@@ -11,17 +11,17 @@ export interface JestConfigOptions {
    *
    * @default 'jest.config.ts'
    */
-  filename?: string
+  readonly filename?: string
 
   /**
    * Name of a Jest configuration package to extend from.
    */
-  extends?: string
+  readonly extends?: string
 
   /**
    * Jest configuration object.
    */
-  config?: Config
+  readonly config?: Config
 }
 
 export class JestConfig extends FileBase {

--- a/packages/projen-lint-staged/src/index.ts
+++ b/packages/projen-lint-staged/src/index.ts
@@ -11,17 +11,17 @@ export interface LintStagedOptions {
    *
    * @default 'lint-staged.config.js'
    */
-  filename?: string
+  readonly filename?: string
 
   /**
    * Name of the `lint-staged` configuration package to extend from.
    */
-  extends?: string
+  readonly extends?: string
 
   /**
    * `lint-staged` configuration.
    */
-  config?: Config
+  readonly config?: Config
 }
 
 export class LintStaged extends FileBase {

--- a/packages/projen-lint-synthesized/src/index.ts
+++ b/packages/projen-lint-synthesized/src/index.ts
@@ -9,7 +9,7 @@ import { Component, Project } from 'projen'
 const debug = createDebug('projen-lint-synthesized')
 
 export interface LintSynthesizedOptions {
-  [pattern: string]: string | ((files: string[]) => string)
+  readonly [pattern: string]: string | ((files: string[]) => string)
 }
 
 /**

--- a/packages/projen-pnpm-workspace/src/index.ts
+++ b/packages/projen-pnpm-workspace/src/index.ts
@@ -12,12 +12,12 @@ export interface PnpmWorkspaceOptions {
    *
    * @default 'pnpm-workspace.yaml'
    */
-  filename?: string
+  readonly filename?: string
 
   /**
    * List of package paths.
    */
-  packages?: string[]
+  readonly packages?: string[]
 }
 
 export class PnpmWorkspace extends YamlFile {
@@ -70,8 +70,9 @@ export class PnpmWorkspace extends YamlFile {
       return
     }
 
-    const parsed: Required<Exclude<PnpmWorkspaceOptions, 'filename'>> =
-      YAML.parse(yaml)
+    const parsed: Writable<
+      Required<Exclude<PnpmWorkspaceOptions, 'filename'>>
+    > = YAML.parse(yaml)
 
     parsed.packages = [...new Set(parsed.packages)]
     parsed.packages.sort()
@@ -90,4 +91,8 @@ export class PnpmWorkspace extends YamlFile {
       this.addToArray('packages', pkg)
     }
   }
+}
+
+type Writable<T> = {
+  -readonly [K in keyof T]: T[K]
 }

--- a/packages/projen-prettier/src/index.ts
+++ b/packages/projen-prettier/src/index.ts
@@ -11,22 +11,22 @@ export interface PrettierOptions {
    *
    * @default 'prettier.config.js'
    */
-  filename?: string
+  readonly filename?: string
 
   /**
    * Name of the Prettier configuration package to extend from.
    */
-  extends?: string
+  readonly extends?: string
 
   /**
    * Ignore patterns.
    */
-  ignorePatterns?: string[]
+  readonly ignorePatterns?: string[]
 
   /**
    * Prettier configuration object.
    */
-  config?: Config
+  readonly config?: Config
 }
 
 export class Prettier extends FileBase {

--- a/packages/projen-project/src/lib/node-package.ts
+++ b/packages/projen-project/src/lib/node-package.ts
@@ -6,8 +6,8 @@ import { Project, javascript } from 'projen'
  * Options for configuring Node.js packages.
  */
 export interface NodePackageOptions extends javascript.NodePackageOptions {
-  peerDependenciesMeta?: Record<string, { optional?: boolean }>
-  type?: 'commonjs' | 'module'
+  readonly peerDependenciesMeta?: Record<string, { optional?: boolean }>
+  readonly type?: 'commonjs' | 'module'
 }
 
 /**

--- a/packages/projen-readme/src/index.ts
+++ b/packages/projen-readme/src/index.ts
@@ -4,7 +4,7 @@ import { Project, SampleFile } from 'projen'
  * Initial `README` for new packages.
  */
 export interface ReadmeFileOptions {
-  filename?: string
+  readonly filename?: string
 }
 
 /**

--- a/packages/projen-typescript-config/src/index.ts
+++ b/packages/projen-typescript-config/src/index.ts
@@ -2,9 +2,9 @@ import type { JSONSchemaForTheTypeScriptCompilerSConfigurationFile } from '@sche
 import { IResolver, JsonFile, Project } from 'projen'
 
 export interface TypeScriptConfigOptions {
-  fileName?: string
+  readonly fileName?: string
 
-  config?: JSONSchemaForTheTypeScriptCompilerSConfigurationFile & {
+  readonly config?: JSONSchemaForTheTypeScriptCompilerSConfigurationFile & {
     /**
      * Referenced projects. Requires TypeScript version 3.0 or later.
      */


### PR DESCRIPTION
First-pass to make Projen types hardened by making root properties read-only.

Related to #834.