### PR TITLE
Restrict linting synthesized files with ESLint and Prettier

### DIFF
--- a/change/@langri-sha-projen-project-6ce81490-d603-4740-a223-2bce318dbe99.json
+++ b/change/@langri-sha-projen-project-6ce81490-d603-4740-a223-2bce318dbe99.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(project): Lint synthesized with ESLint and Prettier when configured",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/src/index.test.ts
+++ b/packages/projen-project/src/index.test.ts
@@ -440,6 +440,20 @@ describe('with `lint-synthesized`', () => {
     synthSnapshot(project)
     expect(LintSynthesized).toHaveBeenCalledWith(project, {
       'package.json': 'pnpx sort-package-json',
+      '*': 'pnpm prettier --write --ignore-unknown',
+    })
+  })
+
+  test('with ESLint', () => {
+    const project = new Project({
+      name: 'test-project',
+      eslint: {},
+      lintSynthesized: {},
+    })
+
+    synthSnapshot(project)
+    expect(LintSynthesized).toHaveBeenCalledWith(project, {
+      'package.json': 'pnpx sort-package-json',
       '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}': 'pnpm eslint --fix',
       '*': 'pnpm prettier --write --ignore-unknown',
     })

--- a/packages/projen-project/src/index.test.ts
+++ b/packages/projen-project/src/index.test.ts
@@ -9,20 +9,30 @@ import { Husky } from '@langri-sha/projen-husky'
 import { JestConfig } from '@langri-sha/projen-jest-config'
 import { License } from '@langri-sha/projen-license'
 import { LintStaged } from '@langri-sha/projen-lint-staged'
+import { LintSynthesized } from '@langri-sha/projen-lint-synthesized'
 import { PnpmWorkspace } from '@langri-sha/projen-pnpm-workspace'
 import { Prettier } from '@langri-sha/projen-prettier'
 import { ReadmeFile } from '@langri-sha/projen-readme'
 import { Renovate } from '@langri-sha/projen-renovate'
 import { SWCConfig } from '@langri-sha/projen-swcrc'
 import { TypeScriptConfig } from '@langri-sha/projen-typescript-config'
-import { describe, expect, test } from '@langri-sha/vitest'
+import { afterEach, describe, expect, test } from '@langri-sha/vitest'
 import { Project as BaseProject, IgnoreFile } from 'projen'
 import { synthSnapshot } from 'projen/lib/util/synth'
+import { vi } from 'vitest'
 
 import { NodePackage, ProjenrcFile } from './lib'
 import { GitAttributesFile } from './lib/gitattributes'
 
 import { Project } from './index'
+
+vi.mock('@langri-sha/projen-lint-synthesized', () => ({
+  LintSynthesized: vi.fn(),
+}))
+
+afterEach(() => {
+  vi.resetAllMocks()
+})
 
 test('defaults', () => {
   const project = new Project({
@@ -417,6 +427,22 @@ describe('with `lint-staged`', () => {
 
     expect(synthSnapshot(project)).toMatchSnapshot()
     expect(project.lintStaged).toBeInstanceOf(LintStaged)
+  })
+})
+
+describe('with `lint-synthesized`', () => {
+  test('defaults', () => {
+    const project = new Project({
+      name: 'test-project',
+      lintSynthesized: {},
+    })
+
+    synthSnapshot(project)
+    expect(LintSynthesized).toHaveBeenCalledWith(project, {
+      'package.json': 'pnpx sort-package-json',
+      '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}': 'pnpm eslint --fix',
+      '*': 'pnpm prettier --write --ignore-unknown',
+    })
   })
 })
 

--- a/packages/projen-project/src/index.test.ts
+++ b/packages/projen-project/src/index.test.ts
@@ -440,7 +440,6 @@ describe('with `lint-synthesized`', () => {
     synthSnapshot(project)
     expect(LintSynthesized).toHaveBeenCalledWith(project, {
       'package.json': 'pnpx sort-package-json',
-      '*': 'pnpm prettier --write --ignore-unknown',
     })
   })
 
@@ -455,6 +454,19 @@ describe('with `lint-synthesized`', () => {
     expect(LintSynthesized).toHaveBeenCalledWith(project, {
       'package.json': 'pnpx sort-package-json',
       '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}': 'pnpm eslint --fix',
+    })
+  })
+
+  test('with Prettier', () => {
+    const project = new Project({
+      name: 'test-project',
+      lintSynthesized: {},
+      prettier: {},
+    })
+
+    synthSnapshot(project)
+    expect(LintSynthesized).toHaveBeenCalledWith(project, {
+      'package.json': 'pnpx sort-package-json',
       '*': 'pnpm prettier --write --ignore-unknown',
     })
   })

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -450,14 +450,16 @@ export class Project extends BaseProject {
     this.typeScriptConfig?.addFile(this.lintStaged!.path)
   }
 
-  #configureLintSynthesized({ lintSynthesized }: ProjectOptions) {
+  #configureLintSynthesized({ eslint, lintSynthesized }: ProjectOptions) {
     if (!lintSynthesized) {
       return
     }
 
     const defaults: LintSynthesizedOptions = {
       'package.json': 'pnpx sort-package-json',
-      '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}': 'pnpm eslint --fix',
+      ...(eslint && {
+        '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}': 'pnpm eslint --fix',
+      }),
       '*': 'pnpm prettier --write --ignore-unknown',
     }
 

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -450,7 +450,11 @@ export class Project extends BaseProject {
     this.typeScriptConfig?.addFile(this.lintStaged!.path)
   }
 
-  #configureLintSynthesized({ eslint, lintSynthesized }: ProjectOptions) {
+  #configureLintSynthesized({
+    eslint,
+    lintSynthesized,
+    prettier,
+  }: ProjectOptions) {
     if (!lintSynthesized) {
       return
     }
@@ -460,7 +464,7 @@ export class Project extends BaseProject {
       ...(eslint && {
         '*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}': 'pnpm eslint --fix',
       }),
-      '*': 'pnpm prettier --write --ignore-unknown',
+      ...(prettier && { '*': 'pnpm prettier --write --ignore-unknown' }),
     }
 
     new LintSynthesized(this, deepMerge(defaults, lintSynthesized))


### PR DESCRIPTION
Restricts linting synthesized files with ESLint and Prettier only when
the two are configured for the project.
