### PR TITLE
Make ESLint and Prettier optional for `lint-staged`

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -318,6 +318,11 @@ project.addSubproject(
       entrypoint: 'src/index.js',
       devDeps: ['@types/lint-staged@13.3.0'],
       peerDeps: ['eslint@^9.0.0', 'lint-staged@^15.0.0', 'prettier@^3.0.0'],
+      peerDependenciesMeta: {
+        eslint: {
+          optional: true,
+        },
+      },
     },
   },
   subproject,

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -322,6 +322,9 @@ project.addSubproject(
         eslint: {
           optional: true,
         },
+        prettier: {
+          optional: true,
+        },
       },
     },
   },

--- a/change/@langri-sha-lint-staged-6f67b3a0-a068-4961-983c-1138a202e228.json
+++ b/change/@langri-sha-lint-staged-6f67b3a0-a068-4961-983c-1138a202e228.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(lint-staged): Make ESlint and Prettier optional",
+  "packageName": "@langri-sha/lint-staged",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/lint-staged/package.json
+++ b/packages/lint-staged/package.json
@@ -33,6 +33,9 @@
   "peerDependenciesMeta": {
     "eslint": {
       "optional": true
+    },
+    "prettier": {
+      "optional": true
     }
   },
   "publishConfig": {

--- a/packages/lint-staged/package.json
+++ b/packages/lint-staged/package.json
@@ -30,6 +30,11 @@
     "lint-staged": "^15.0.0",
     "prettier": "^3.0.0"
   },
+  "peerDependenciesMeta": {
+    "eslint": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public",
     "main": "dist/index.js",

--- a/packages/lint-staged/src/index.js
+++ b/packages/lint-staged/src/index.js
@@ -1,13 +1,11 @@
-import { ESLint } from 'eslint'
-import * as prettier from 'prettier'
-
-const eslintCli = new ESLint()
-
 /**
  * @type {import('lint-staged').Config}
  */
 export default {
   '*.{js,cjs,mjs,jsx,ts,mts,tsx}': async (files) => {
+    const { ESLint } = await import('eslint')
+    const eslintCli = new ESLint()
+
     /** @type {[string, boolean][]} */
     const ignored = await Promise.all(
       files.map(async (file) => [file, await eslintCli.isPathIgnored(file)]),
@@ -19,6 +17,8 @@ export default {
     return `eslint --fix ${filtered.join(' ')}`
   },
   '*': async (files) => {
+    const prettier = await import('prettier')
+
     const options = { ignorePath: './.prettierignore' }
 
     /** @type {[string, import('prettier').FileInfoResult][]} */

--- a/packages/lint-staged/src/index.js
+++ b/packages/lint-staged/src/index.js
@@ -24,7 +24,13 @@ export default {
     return `eslint --fix ${filtered.join(' ')}`
   },
   '*': async (files) => {
-    const prettier = await import('prettier')
+    let prettier
+
+    try {
+      prettier = await import('prettier')
+    } catch {
+      return ''
+    }
 
     const options = { ignorePath: './.prettierignore' }
 

--- a/packages/lint-staged/src/index.js
+++ b/packages/lint-staged/src/index.js
@@ -3,7 +3,14 @@
  */
 export default {
   '*.{js,cjs,mjs,jsx,ts,mts,tsx}': async (files) => {
-    const { ESLint } = await import('eslint')
+    let ESLint
+
+    try {
+      ESLint = (await import('eslint'))['ESLint']
+    } catch {
+      return ''
+    }
+
     const eslintCli = new ESLint()
 
     /** @type {[string, boolean][]} */


### PR DESCRIPTION
Makes ESLint and Prettier optional for running `lint-staged`.
