### PR TITLE
Migrate to `matchPackageNames`

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -87,7 +87,7 @@ const project = new Project({
         groupName: 'Google Providers',
         groupSlug: 'terraform-google',
         matchDatasources: ['terraform-provider'],
-        matchPackagePrefixes: 'hashicorp/google',
+        matchPackageNames: 'hashicorp/google*',
       },
     ],
   },

--- a/renovate.json5
+++ b/renovate.json5
@@ -55,7 +55,7 @@
       groupName: 'Google Providers',
       groupSlug: 'terraform-google',
       matchDatasources: ['terraform-provider'],
-      matchPackagePrefixes: 'hashicorp/google',
+      matchPackageNames: 'hashicorp/google*',
     },
   ],
 }


### PR DESCRIPTION
Migrates configuration for `matchPackage*`.

See: https://github.com/renovatebot/renovate/releases/tag/38.0.0.