### PR TITLE
Supress `keyv-file` type errors

### DIFF
--- a/change/@langri-sha-schemastore-to-typescript-02c10be5-67cf-4770-bd8b-09ab92f840e2.json
+++ b/change/@langri-sha-schemastore-to-typescript-02c10be5-67cf-4770-bd8b-09ab92f840e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(schemastore-to-typescript): Supress `keyv-file` type errors",
+  "packageName": "@langri-sha/schemastore-to-typescript",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/schemastore-to-typescript/src/index.ts
+++ b/packages/schemastore-to-typescript/src/index.ts
@@ -13,6 +13,7 @@ import { KeyvFile } from 'keyv-file'
 const debug = createDebug('schema-store-to-typescript')
 const paths = envPaths('schemastore-to-typescript')
 
+// @ts-expect-error: Error with `keyv-file` package.
 const keyv = new Keyv({
   store: new KeyvFile({
     filename: path.join(paths.cache, 'requests.json'),


### PR DESCRIPTION
Suppresses type errors from `keyv-file` upgrade.

Fixes #945.