### PR TITLE
feat(schemastore-to-typescript): Fetch schemas via catalog API

### DIFF
--- a/change/@langri-sha-schemastore-to-typescript-0b1eab69-6626-4169-a89c-f56c0561142f.json
+++ b/change/@langri-sha-schemastore-to-typescript-0b1eab69-6626-4169-a89c-f56c0561142f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Refactor schema fetching to use catalog API and improve tests",
+  "packageName": "@langri-sha/schemastore-to-typescript",
+  "email": "bot@langri-sha.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/schemastore-to-typescript/readme.md
+++ b/packages/schemastore-to-typescript/readme.md
@@ -1,15 +1,23 @@
 # @langri-sha/schemastore-to-typescript
 
-Fetch [JSON Schema] from the [JSON Schema Store] and compiles [TypeScript
+Fetch [JSON Schema] from the [JSON Schema Store] catalog and compile [TypeScript
 typings].
+
+The tool first fetches the schema catalog from the JSON Schema Store API,
+searches for the requested schema by name (case-insensitive), and then downloads
+and compiles the schema to TypeScript definitions.
 
 ## Features
 
-- uses [`json-schema-to-typescript`]
-- offline cache using [`got`]
+- uses [`json-schema-to-typescript`] for TypeScript generation
+- fetches schemas from the [JSON Schema Store catalog API]
+- case-insensitive schema name matching
+- offline cache using [`got`] for both catalog and schema requests
 
 [got]: https://www.npmjs.com/package/got
-[json schema store]: https://www.schemastore.org/json/
+[json schema store]: https://www.schemastore.org/
+[json schema store catalog api]:
+  https://www.schemastore.org/api/json/catalog.json
 [json schema]: https://json-schema.org/
 [json-schema-to-typescript]:
   https://www.npmjs.com/package/json-schema-to-typescript

--- a/packages/schemastore-to-typescript/src/index.ts
+++ b/packages/schemastore-to-typescript/src/index.ts
@@ -21,32 +21,116 @@ const keyv = new Keyv({
   }),
 })
 
+interface CatalogSchema {
+  name: string
+  description: string
+  fileMatch?: string[]
+  url: string
+}
+
+interface Catalog {
+  $schema: string
+  version: number
+  schemas: CatalogSchema[]
+}
+
 export const compile = async (
   name: string,
   cache: boolean = true,
 ): Promise<string> => {
-  let schema
+  const catalogUrl = 'https://www.schemastore.org/api/json/catalog.json'
 
-  const url = new URL(name, 'https://json.schemastore.org').toString()
+  let catalog: Catalog
+  let schema: JSONSchema
+
+  const fetchWithRetry = async <T>(
+    url: string,
+    retryOnCacheError: boolean = true,
+  ): Promise<T> => {
+    try {
+      return await got(url, {
+        cache: cache ? keyv : undefined,
+        headers: {
+          accept: 'application/json',
+        },
+        decompress: true,
+      }).json<T>()
+    } catch (e) {
+      debug(`Error fetching ${url}:`, e)
+
+      if (
+        retryOnCacheError &&
+        cache &&
+        e instanceof Error &&
+        (e.message.includes('Unexpected token') ||
+          e.message.includes('is not valid JSON'))
+      ) {
+        debug(`Clearing cache for ${url} and retrying...`)
+        try {
+          await keyv.delete(`GET:${url}`)
+        } catch (clearError) {
+          debug(`Failed to clear cache:`, clearError)
+        }
+
+        return fetchWithRetry<T>(url, false)
+      }
+
+      throw e
+    }
+  }
 
   try {
-    schema = await got(url, {
-      cache: cache ? keyv : undefined,
-      headers: {
-        accept: '*/*',
-      },
-    }).json<JSONSchema>()
+    // First, fetch the catalog
+    catalog = await fetchWithRetry<Catalog>(catalogUrl)
+  } catch (e) {
+    debug(e)
+
+    if (e instanceof HTTPError) {
+      throw new Error(
+        `Couldn't retrieve catalog from ${catalogUrl}. [${e.code}]`,
+      )
+    }
+
+    throw e
+  }
+
+  const schemaMap = new Map<string, CatalogSchema>()
+  for (const schema of catalog.schemas) {
+    schemaMap.set(schema.name.toLowerCase(), schema)
+  }
+
+  const catalogSchema = schemaMap.get(name.toLowerCase())
+
+  if (!catalogSchema) {
+    throw new Error(
+      `Couldn't find schema ${name} in the catalog. Are you sure it exists?`,
+    )
+  }
+
+  try {
+    // Fetch the actual schema from the found URL
+    debug(`Fetching schema from: ${catalogSchema.url}`)
+
+    schema = await fetchWithRetry<JSONSchema>(catalogSchema.url)
   } catch (e) {
     debug(e)
 
     if (e instanceof HTTPError) {
       if (e.response.statusCode === 404) {
         throw new Error(
-          `Couldn't find schema ${name} at ${url}. Are you sure it exists?`,
+          `Couldn't find schema ${name} at ${catalogSchema.url}. Are you sure it exists?`,
         )
       }
 
-      throw new Error(`Couldn't retrieve schema from ${url}. [${e.code}]`)
+      throw new Error(
+        `Couldn't retrieve schema from ${catalogSchema.url}. [${e.code}] Status: ${e.response.statusCode}`,
+      )
+    }
+
+    if (e instanceof Error && e.message.includes('is not valid JSON')) {
+      throw new Error(
+        `Failed to parse JSON from ${catalogSchema.url}. The server might be returning invalid or compressed content. Error: ${e.message}`,
+      )
     }
 
     throw e


### PR DESCRIPTION
This PR implements fetching schemas via the catalog API for the schemastore-to-typescript functionality.

Changes include:
- Updated schema fetching mechanism to use catalog API
- Improved schema retrieval process

This enhances the reliability and efficiency of schema processing.