### PR TITLE
fix(projen-swcrc): Use correct type name from generated schema

### DIFF
--- a/change/@langri-sha-projen-swcrc-3d5c068f-dee2-449d-b65f-f5b8108fe48f.json
+++ b/change/@langri-sha-projen-swcrc-3d5c068f-dee2-449d-b65f-f5b8108fe48f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(projen-swcrc): Use correct type name from generated schema",
+  "packageName": "@langri-sha/projen-swcrc",
+  "email": "bot@langri-sha.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-swcrc/src/index.ts
+++ b/packages/projen-swcrc/src/index.ts
@@ -1,11 +1,11 @@
 import { JsonFile, type Project } from 'projen'
 
-import { type SwcConfigurationSchema } from './swcrc'
+import { type Swcrc } from './swcrc'
 
 /**
  * SWC configuration options.
  */
-export type SWCConfigOptions = SwcConfigurationSchema
+export type SWCConfigOptions = Swcrc
 
 /**
  * A component for managing Renovate configurations.


### PR DESCRIPTION
Fixes TypeScript error TS2305 by importing the correct type name `Swcrc` instead of the non-existent `SwcConfigurationSchema` from the generated schema definitions.

The `json-schema-to-typescript` tool generates the main interface as `Swcrc`, not `SwcConfigurationSchema`.

## Changes
- Updated import in `packages/projen-swcrc/src/index.ts` to use `Swcrc` type
- Updated `SWCConfigOptions` type alias accordingly
- Added beachball change file for patch version bump