### PR TITLE
fix: mock Date.getFullYear() in license year tests for consistency

### DIFF
--- a/packages/projen-project/src/index.test.ts
+++ b/packages/projen-project/src/index.test.ts
@@ -16,7 +16,14 @@ import { ReadmeFile } from '@langri-sha/projen-readme'
 import { Renovate } from '@langri-sha/projen-renovate'
 import { SWCConfig } from '@langri-sha/projen-swcrc'
 import { TypeScriptConfig } from '@langri-sha/projen-typescript-config'
-import { afterEach, describe, expect, test } from '@langri-sha/vitest'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  test,
+} from '@langri-sha/vitest'
 import { Project as BaseProject, IgnoreFile } from 'projen'
 import { synthSnapshot } from 'projen/lib/util/synth'
 import { vi } from 'vitest'
@@ -29,6 +36,16 @@ import { Project } from './index'
 vi.mock('@langri-sha/projen-lint-synthesized', () => ({
   LintSynthesized: vi.fn(),
 }))
+
+// Mock system time to January 1, 2024 for consistent test snapshots
+beforeAll(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2024-01-01'))
+})
+
+afterAll(() => {
+  vi.useRealTimers()
+})
 
 afterEach(() => {
   vi.resetAllMocks()


### PR DESCRIPTION
## Problem
Tests were using the current year which would fail in future years. The license year tests were not deterministic and would break when the calendar year changed.

## Solution
Mock `Date.getFullYear()` to always return 2024 in the test. This ensures the test runs with a fixed, predictable year value regardless of when the test is executed.

## Impact
Ensures license year tests remain stable regardless of when they run. This change makes the test suite more reliable and prevents future test failures due to year changes.

## Testing
The test now passes consistently with the mocked Date function, providing stable and predictable results across different execution times.

---

*Note: This PR also includes a fix for projen-swcrc type import issues.*