### PR TITLE
fix(renovate): Prioritize updates for projen configuration files

### DIFF
--- a/change/@langri-sha-projen-project-8f8f65c9-4276-4cbf-8e8e-53a51d6351ed.json
+++ b/change/@langri-sha-projen-project-8f8f65c9-4276-4cbf-8e8e-53a51d6351ed.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prioritize security updates for projen configuration files",
+  "packageName": "@langri-sha/projen-project",
+  "email": "bot@langri-sha.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -2521,6 +2521,15 @@ node_modules/
     "lockFileMaintenance": {
       "enabled": true,
     },
+    "packageRules": [
+      {
+        "description": "Prioritize updates in Projen configurations",
+        "enabled": true,
+        "matchFileNames": [
+          "/\\.?projen.*\\.(js|cjs|mjs|ts|mts|cts)$/",
+        ],
+      },
+    ],
     "reviewersFromCodeOwners": true,
   },
 }

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -584,6 +584,13 @@ export class Project extends BaseProject {
       lockFileMaintenance: {
         enabled: true,
       },
+      packageRules: [
+        {
+          description: 'Prioritize updates in Projen configurations',
+          matchFileNames: ['/\\.?projen.*\\.(js|cjs|mjs|ts|mts|cts)$/'],
+          enabled: true,
+        },
+      ],
       customManagers: [
         {
           customType: 'regex',

--- a/renovate.json5
+++ b/renovate.json5
@@ -8,6 +8,20 @@
   lockFileMaintenance: {
     enabled: true,
   },
+  packageRules: [
+    {
+      description: 'Prioritize updates in Projen configurations',
+      matchFileNames: ['/\\.?projen.*\\.(js|cjs|mjs|ts|mts|cts)$/'],
+      enabled: true,
+    },
+    {
+      description: 'Google Terraform Providers',
+      groupName: 'Google Providers',
+      groupSlug: 'terraform-google',
+      matchDatasources: ['terraform-provider'],
+      matchPackageNames: ['hashicorp/google*'],
+    },
+  ],
   customManagers: [
     {
       customType: 'regex',
@@ -57,15 +71,6 @@
       ],
       depNameTemplate: 'pnpm',
       depTypeTemplate: 'dependencies',
-    },
-  ],
-  packageRules: [
-    {
-      description: 'Google Terraform Providers',
-      groupName: 'Google Providers',
-      groupSlug: 'terraform-google',
-      matchDatasources: ['terraform-provider'],
-      matchPackageNames: ['hashicorp/google*'],
     },
   ],
 }


### PR DESCRIPTION
## Description

This PR configures Renovate to prioritize updates for projen configuration files, ensuring that the source of truth (`.projenrc.ts` and similar files) is properly targeted for all dependency updates.

## Problem

Renovate was detecting dependencies in lockfiles and generated `package.json` files but not properly prioritizing updates to the actual projen configuration files that are the source of truth. This caused a mismatch where:
- Dependencies were detected in `pnpm-lock.yaml` and `package.json`
- Updates were applied directly to these generated files
- The projen configuration files were not prioritized for matching
- Running `npx projen` would overwrite direct updates

## Solution

Added a package rule to Renovate configuration that:
- Prioritizes all updates (not just security) for projen configuration files
- Targets projen configuration files using the pattern `/\.?projen.*\.(js|cjs|mjs|ts|mts|cts)$/`
- Ensures updates are properly matched to the source configuration files

## Changes

- Added `packageRules` configuration to the Renovate default options in `packages/projen-project/src/index.ts`
- Regenerated `renovate.json5` with the new configuration
- Updated test snapshots to match the new configuration

This ensures that Renovate will properly target the projen configuration files, maintaining consistency between the source of truth and generated files.