### PR TITLE
Update import for renamed Renovate schema type

### DIFF
--- a/change/@langri-sha-projen-renovate-7a22c66d-53e5-43f0-82c6-b082cb7f7dc5.json
+++ b/change/@langri-sha-projen-renovate-7a22c66d-53e5-43f0-82c6-b082cb7f7dc5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(projen-renovate): Update import for renamed schema type",
+  "packageName": "@langri-sha/projen-renovate",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-renovate/src/index.ts
+++ b/packages/projen-renovate/src/index.ts
@@ -1,12 +1,12 @@
 import { Component, JsonFile, type Project } from 'projen'
 
-import { type JSONSchemaForRenovateConfigFilesHttpsRenovatebotCom } from './renovate'
+import { type JSONSchemaForRenovate42931ConfigFilesHttpsRenovatebotCom } from './renovate'
 
 /**
  * Renovate configuration options.
  */
 export interface RenovateOptions
-  extends JSONSchemaForRenovateConfigFilesHttpsRenovatebotCom {}
+  extends JSONSchemaForRenovate42931ConfigFilesHttpsRenovatebotCom {}
 
 /**
  * A component for managing Renovate configurations.


### PR DESCRIPTION
## Summary
- Update `@langri-sha/projen-renovate` to use the renamed schema type export from `@schemastore/renovate`
- The schema type was renamed from `JSONSchemaForRenovateConfigFilesHttpsRenovatebotCom` to `JSONSchemaForRenovate42931ConfigFilesHttpsRenovatebotCom`

## Test plan
- [x] Build passes
- [x] Types are correctly exported and extend the updated schema type