### PR TITLE
feat(terraform/web): Enable monitoring API

### DIFF
--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -118,6 +118,7 @@ locals {
         "compute.googleapis.com",
         "dns.googleapis.com",
         "iap.googleapis.com",
+        "monitoring.googleapis.com",
       ]
 
       iam_members = {


### PR DESCRIPTION
## Summary
Enables the Google Cloud Monitoring API for the web infrastructure project.

## Changes
- Added `monitoring.googleapis.com` to the list of enabled APIs in the web Terraform configuration

## Files Modified
- `terraform/web/main.tf`