### PR TITLE
fix(projen-renovate): Update import for regenerated schema type

### DIFF
--- a/change/@langri-sha-projen-renovate-e1774475-238c-493b-ba1a-e85dcc4ca95c.json
+++ b/change/@langri-sha-projen-renovate-e1774475-238c-493b-ba1a-e85dcc4ca95c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(projen-renovate): use stable Renovate schema type from schemastore-to-typescript",
+  "packageName": "@langri-sha/projen-renovate",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-schemastore-to-typescript-9bab22e6-d3c2-4fa8-a32d-a076a933579d.json
+++ b/change/@langri-sha-schemastore-to-typescript-9bab22e6-d3c2-4fa8-a32d-a076a933579d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix(schemastore-to-typescript): stabilize generated type names by overriding schema title with catalog name",
+  "packageName": "@langri-sha/schemastore-to-typescript",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/projen-renovate/src/index.ts
+++ b/packages/projen-renovate/src/index.ts
@@ -1,12 +1,11 @@
 import { Component, JsonFile, type Project } from 'projen'
 
-import { type JSONSchemaForRenovate42931ConfigFilesHttpsRenovatebotCom } from './renovate'
+import { type Renovate as RenovateSchema } from './renovate'
 
 /**
  * Renovate configuration options.
  */
-export interface RenovateOptions
-  extends JSONSchemaForRenovate42931ConfigFilesHttpsRenovatebotCom {}
+export interface RenovateOptions extends RenovateSchema {}
 
 /**
  * A component for managing Renovate configurations.

--- a/packages/schemastore-to-typescript/src/index.test.ts
+++ b/packages/schemastore-to-typescript/src/index.test.ts
@@ -67,7 +67,7 @@ test('compiles to TypeScript', async () => {
      * and run json-schema-to-typescript to regenerate this file.
      */
 
-    export interface SomeSchema {
+    export interface Some {
       /**
        * The unique identifier for some item.
        */

--- a/packages/schemastore-to-typescript/src/index.ts
+++ b/packages/schemastore-to-typescript/src/index.ts
@@ -112,6 +112,10 @@ export const compile = async (
     debug(`Fetching schema from: ${catalogSchema.url}`)
 
     schema = await fetchWithRetry<JSONSchema>(catalogSchema.url)
+
+    if (typeof schema === 'object' && schema !== null) {
+      schema.title = catalogSchema.name
+    }
   } catch (e) {
     debug(e)
 


### PR DESCRIPTION
## Summary
CI was failing after PR #1012 with a TypeScript compilation error in `packages/projen-renovate/src/index.ts` because the renovate schema type was regenerated and renamed. The original patch pinned a new version-qualified name, but the schema republished during CI and broke the build again — so this PR also lands a root-cause fix that stabilizes the generated type names.

## Changes
- **`packages/schemastore-to-typescript/src/index.ts`**: override the fetched schema's `title` with the catalog's canonical name before handing it to `json-schema-to-typescript`. This stabilizes the generated top-level type across upstream schema republishes. See #1015 for full context.
- **`packages/projen-renovate/src/index.ts`**: import `Renovate` (aliased to `RenovateSchema` to avoid colliding with the local `Renovate` class) instead of the version-qualified `JSONSchemaForRenovate…`.
- **`packages/schemastore-to-typescript/src/index.test.ts`**: update one inline snapshot (`SomeSchema` → `Some`) to match the new catalog-name-is-source-of-truth behavior.
- Add beachball patch change file for `@langri-sha/projen-renovate`.

## Test plan
- [x] `pnpm tsc --build .` clean
- [x] `vitest run` passes across `schemastore-to-typescript`, `projen-renovate`, `projen-swcrc`
- [ ] CI build completes successfully

Fixes #1013
Fixes #1015