### PR TITLE
Default EXPERIMENTAL_SCENE to empty string in EnvironmentPlugin

### DIFF
--- a/apps/web/webpack.config.ts
+++ b/apps/web/webpack.config.ts
@@ -117,7 +117,7 @@ const configuration: (options: Options) => Configuration = env(
       }),
       new EnvironmentPlugin({
         NODE_ENV: environment,
-        EXPERIMENTAL_SCENE: null,
+        EXPERIMENTAL_SCENE: '',
       } satisfies WebEnv),
     ],
   }),


### PR DESCRIPTION
## Summary

The Web build on `main` started failing (run [#2004](https://github.com/langri-sha/langri-sha.com/actions/runs/25066546561/job/73435133185)) after webpack reached **5.94.0** in the lockfile. webpack 5.94 narrowed `EnvironmentPlugin`'s constructor signature from `(...keys: any[])` to `(...keys: (string | string[] | Record<string, string>)[])`, so passing `null` as a default value is no longer assignable.

```
./webpack.config.ts:118:29
Type error: Argument of type '{ NODE_ENV: ...; EXPERIMENTAL_SCENE: null; }'
is not assignable to parameter of type 'string | string[] | Record<string, string>'.
  Types of property 'EXPERIMENTAL_SCENE' are incompatible.
    Type 'null' is not assignable to type 'string | undefined'.
```

The original `null` told webpack "this var must be set in the build env, warn otherwise". Switching to `''` keeps the falsy runtime substitution when `EXPERIMENTAL_SCENE` is unset, at the cost of dropping that build-time warning — fine here since the scene is genuinely optional.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm build` — compiles, type-checks, and emits the bundle locally
- [ ] CI (`Web / Build`) green on this PR