### PR TITLE
fix(eslint-config): allow interface single-extends

### DIFF
--- a/change/@langri-sha-eslint-config-6666995e-a1a2-4a22-8442-401082b1b63a.json
+++ b/change/@langri-sha-eslint-config-6666995e-a1a2-4a22-8442-401082b1b63a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: allow `interface X extends Y {}` (no-empty-object-type with-single-extends)",
+  "packageName": "@langri-sha/eslint-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/eslint-config/.projen/deps.json
+++ b/packages/eslint-config/.projen/deps.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "typescript-eslint",
-      "version": "7.18.0",
+      "version": "8.59.1",
       "type": "runtime"
     }
   ],

--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -54,6 +54,10 @@ export default [
       ],
 
       // Contributing.
+      '@typescript-eslint/no-empty-object-type': [
+        'error',
+        { allowInterfaces: 'with-single-extends' },
+      ],
       '@typescript-eslint/no-unused-vars': [
         'error',
         {


### PR DESCRIPTION
## Summary

- Re-enables `main` CI by relaxing `@typescript-eslint/no-empty-object-type` to permit the `with-single-extends` pattern.
- The `typescript-eslint` v8 upgrade in #889 turned this rule on by default, which broke two legitimate uses of `interface X extends Y {}`:
  - `apps/web/src/web.d.ts` — `interface ProcessEnv extends WebEnv {}` for `NodeJS.ProcessEnv` declaration merging.
  - `packages/projen-renovate/src/index.ts` — `interface RenovateOptions extends RenovateSchema {}` as a named alias.
- Both are idiomatic TypeScript; this is the minimal, root-cause fix in the shared `@langri-sha/eslint-config` package.

## Test plan

- [x] `pnpm install --frozen-lockfile`
- [x] `npx eslint .` → clean
- [ ] CI green on this PR