### PR TITLE
Grant id-token: write to release job for npm OIDC

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: langri-sha/github/.github/workflows/packages.yml@v0.7.2
+    uses: langri-sha/github/.github/workflows/packages.yml@v0.8.0
     with:
       environment: release
       scope: '@langri-sha'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   packages:
     name: Packages
+    permissions:
+      id-token: write
+      contents: read
     uses: langri-sha/github/.github/workflows/packages.yml@v0.7.2
     with:
       environment: release


### PR DESCRIPTION
Closes #1033.

Grants the `id-token: write` permission on the release job so the reusable [`langri-sha/github/.github/workflows/packages.yml`](https://github.com/langri-sha/github/blob/main/.github/workflows/packages.yml) workflow can authenticate to npm via OIDC trusted publishing. The permission must be declared on the calling workflow so it propagates into the reusable workflow.

Paired with langri-sha/github#37, which drops the `NPM_TOKEN` plumbing on the reusable workflow side. Both need to land (and `langri-sha/github` needs a new tag consumed by this repo) before the secret can be removed.

Registry-side trust configuration (`npm trust github <pkg> ...`) is handled out-of-band.