### PR TITLE
fix(schemastore-to-typescript): remove unused @ts-expect-error directive

### DIFF
--- a/change/@langri-sha-schemastore-to-typescript-15f3e0fc-60db-4c99-8a80-75b39bc58957.json
+++ b/change/@langri-sha-schemastore-to-typescript-15f3e0fc-60db-4c99-8a80-75b39bc58957.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(schemastore-to-typescript): remove unused @ts-expect-error directive (TS2578)",
+  "packageName": "@langri-sha/schemastore-to-typescript",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/schemastore-to-typescript/src/index.ts
+++ b/packages/schemastore-to-typescript/src/index.ts
@@ -13,7 +13,6 @@ import { KeyvFile } from 'keyv-file'
 const debug = createDebug('schema-store-to-typescript')
 const paths = envPaths('schemastore-to-typescript')
 
-// @ts-expect-error: Error with `keyv-file` package.
 const keyv = new Keyv({
   store: new KeyvFile({
     filename: path.join(paths.cache, 'requests.json'),


### PR DESCRIPTION
## Summary

Removes a now-unused `// @ts-expect-error: Error with \`keyv-file\` package.` directive at `packages/schemastore-to-typescript/src/index.ts:16`.

The `keyv-file` upgrade `5.0.2 → 5.3.3` (already merged to `main`) fixed the underlying `KeyvFile` typing issue, so the suppression is no longer needed. With the stricter unused-directive checking, TypeScript flags it as:

```
packages/schemastore-to-typescript/src/index.ts(16,1): error TS2578: Unused '@ts-expect-error' directive.
```

This was failing the **check / Lint** (TypeScript) job on `main` on every push, which gates and blocks all open Renovate PRs.

## Changes

- Remove the unnecessary `@ts-expect-error` directive. The surrounding `new Keyv({ store: new KeyvFile({...}) })` logic is untouched and now type-checks cleanly under `keyv-file@5.3.3`.
- Add a beachball `patch` change file for `@langri-sha/schemastore-to-typescript`.

## Verification

- `pnpm install` regenerates the gitignored `.d.ts` files (incl. `packages/projen-renovate/src/renovate.d.ts`, which exports `interface Renovate` matching the `type Renovate as RenovateSchema` import — no type drift).
- `pnpm exec tsc --build` → exit 0, no TS2578, no new errors.
- `pnpm exec eslint .` → exit 0.
- `pnpm exec beachball check` → exit 0.