### PR TITLE
Pass repo secrets to the reusable check workflow

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    uses: langri-sha/github/.github/workflows/check.yml@v0.7.2
+    uses: langri-sha/github/.github/workflows/check.yml@v0.9.0
     with:
       beachball: true
       eslint: true

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -17,3 +17,4 @@ jobs:
       projen: true
       typescript: true
       vitest: true
+    secrets: inherit


### PR DESCRIPTION
Closes #1042.

## Summary

- Add `secrets: inherit` to the `check` job in `workspace.yml` so the reusable workflow can read `APP_ID` / `APP_PRIVATE_KEY` (already set as repo secrets).
- Pairs with langri-sha/github#45, which switches the post-upgrade push to use the App token.
- The `check.yml@v0.7.2` ref bump should land as a follow-up once a new release ships from langri-sha/github.

## Test plan

- [ ] After langri-sha/github#45 is tagged and the ref bumped here, rebase one open Renovate PR and confirm `Web`/`Workspace` checks now report on the post-mutation head commit.
