### PR TITLE
Migrate from ts-node ESM loader to tsx (Node 24)

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -96,8 +96,8 @@
       "type": "build"
     },
     {
-      "name": "ts-node",
-      "version": "10.9.2",
+      "name": "tsx",
+      "version": "4.22.4",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -14,7 +14,7 @@
       "description": "Synthesize project files",
       "steps": [
         {
-          "exec": "node --loader ts-node/esm/transpile-only .projenrc.ts"
+          "exec": "tsx .projenrc.ts"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -53,7 +53,7 @@ const project = new Project({
       'lint-staged@15.5.2',
       'prettier@3.3.3',
       'projen@0.86.5',
-      'ts-node@10.9.2',
+      'tsx@4.22.4',
       'vitest@2.0.5',
     ],
   },
@@ -693,7 +693,7 @@ project.addSubproject(
         'lint-staged@^15.0.0',
         'prettier@^3.0.0',
         'projen@^0.86.0',
-        'ts-node@^10.0.0',
+        'tsx@^4.0.0',
         'typescript@^5.5.0',
       ],
       peerDependenciesMeta: {
@@ -727,7 +727,7 @@ project.addSubproject(
         prettier: {
           optional: true,
         },
-        'ts-node': {
+        tsx: {
           optional: true,
         },
       },
@@ -772,7 +772,10 @@ project.addSubproject(
       ...pkg,
       copyrightYear: '2024',
       type: 'module',
-      devDeps: ['@langri-sha/schemastore-to-typescript@workspace:*'],
+      devDeps: [
+        '@langri-sha/schemastore-to-typescript@workspace:*',
+        'tsx@4.22.4',
+      ],
       peerDeps: ['projen@^0.86.0'],
     },
   },
@@ -784,7 +787,7 @@ project.addSubproject(
 
     project.package?.setScript(
       'prepare',
-      'NODE_OPTIONS="--loader ts-node/esm/transpile-only" schemastore-to-typescript renovate src/renovate.d.ts',
+      'tsx ./node_modules/@langri-sha/schemastore-to-typescript/src/cli.ts renovate src/renovate.d.ts',
     )
   },
 )
@@ -802,7 +805,10 @@ project.addSubproject(
       ...pkg,
       copyrightYear: '2024',
       type: 'module',
-      devDeps: ['@langri-sha/schemastore-to-typescript@workspace:*'],
+      devDeps: [
+        '@langri-sha/schemastore-to-typescript@workspace:*',
+        'tsx@4.22.4',
+      ],
       peerDeps: ['projen@^0.86.0', '@swc/core@^1.6.0'],
     },
   },
@@ -814,7 +820,7 @@ project.addSubproject(
 
     project.package?.setScript(
       'prepare',
-      'NODE_OPTIONS="--loader ts-node/esm/transpile-only" schemastore-to-typescript swcrc src/swcrc.d.ts',
+      'tsx ./node_modules/@langri-sha/schemastore-to-typescript/src/cli.ts swcrc src/swcrc.d.ts',
     )
   },
 )

--- a/change/@langri-sha-projen-project-115f211e-2529-4b5b-8b62-0f68a558daf7.json
+++ b/change/@langri-sha-projen-project-115f211e-2529-4b5b-8b62-0f68a558daf7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Migrate from the deprecated ts-node ESM loader to tsx for Node 24 compatibility",
+  "packageName": "@langri-sha/projen-project",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-renovate-bdf897fe-2eba-47d9-a034-85ab4cb9d05b.json
+++ b/change/@langri-sha-projen-renovate-bdf897fe-2eba-47d9-a034-85ab4cb9d05b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Migrate from the deprecated ts-node ESM loader to tsx for Node 24 compatibility",
+  "packageName": "@langri-sha/projen-renovate",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-projen-swcrc-0e0eb805-7ab1-47d5-8eb0-9a7800a67538.json
+++ b/change/@langri-sha-projen-swcrc-0e0eb805-7ab1-47d5-8eb0-9a7800a67538.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Migrate from the deprecated ts-node ESM loader to tsx for Node 24 compatibility",
+  "packageName": "@langri-sha/projen-swcrc",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "lint-staged": "15.5.2",
     "prettier": "3.3.3",
     "projen": "0.86.5",
-    "ts-node": "10.9.2",
+    "tsx": "4.22.4",
     "typescript": "5.5.4",
     "vitest": "2.0.5"
   },

--- a/packages/projen-project/.projen/deps.json
+++ b/packages/projen-project/.projen/deps.json
@@ -71,8 +71,8 @@
       "type": "peer"
     },
     {
-      "name": "ts-node",
-      "version": "^10.0.0",
+      "name": "tsx",
+      "version": "^4.0.0",
       "type": "peer"
     },
     {

--- a/packages/projen-project/package.json
+++ b/packages/projen-project/package.json
@@ -57,7 +57,7 @@
     "lint-staged": "^15.0.0",
     "prettier": "^3.0.0",
     "projen": "^0.86.0",
-    "ts-node": "^10.0.0",
+    "tsx": "^4.0.0",
     "typescript": "^5.5.0"
   },
   "peerDependenciesMeta": {
@@ -91,7 +91,7 @@
     "prettier": {
       "optional": true
     },
-    "ts-node": {
+    "tsx": {
       "optional": true
     }
   },

--- a/packages/projen-project/src/__snapshots__/index.test.ts.snap
+++ b/packages/projen-project/src/__snapshots__/index.test.ts.snap
@@ -50,7 +50,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -128,7 +128,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -251,7 +251,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.ts",
+            "exec": "tsx .projenrc.ts",
           },
         ],
       },
@@ -357,7 +357,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -426,7 +426,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -502,7 +502,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -597,9 +597,9 @@ node_modules/
         "version": "0.86.5",
       },
       {
-        "name": "ts-node",
+        "name": "tsx",
         "type": "build",
-        "version": "10.9.2",
+        "version": "4.22.4",
       },
       {
         "name": "typescript",
@@ -628,7 +628,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.ts",
+            "exec": "tsx .projenrc.ts",
           },
         ],
       },
@@ -677,7 +677,7 @@ node_modules/
       "@langri-sha/projen-project": "*",
       "@langri-sha/tsconfig": "*",
       "projen": "0.86.5",
-      "ts-node": "10.9.2",
+      "tsx": "4.22.4",
       "typescript": "5.5.4",
     },
     "license": "Apache-2.0",
@@ -761,7 +761,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -856,9 +856,9 @@ node_modules/
         "version": "0.86.5",
       },
       {
-        "name": "ts-node",
+        "name": "tsx",
         "type": "build",
-        "version": "10.9.2",
+        "version": "4.22.4",
       },
       {
         "name": "typescript",
@@ -887,7 +887,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.ts",
+            "exec": "tsx .projenrc.ts",
           },
         ],
       },
@@ -936,7 +936,7 @@ export default config
       "@langri-sha/projen-project": "*",
       "@langri-sha/tsconfig": "*",
       "projen": "0.86.5",
-      "ts-node": "10.9.2",
+      "tsx": "4.22.4",
       "typescript": "5.5.4",
     },
     "license": "Apache-2.0",
@@ -1038,9 +1038,9 @@ CHANGELOG.md
         "version": "0.86.5",
       },
       {
-        "name": "ts-node",
+        "name": "tsx",
         "type": "build",
-        "version": "10.9.2",
+        "version": "4.22.4",
       },
       {
         "name": "typescript",
@@ -1080,7 +1080,7 @@ CHANGELOG.md
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -1133,7 +1133,7 @@ module.exports = {
       "@langri-sha/tsconfig": "*",
       "beachball": "2.65.5",
       "projen": "0.86.5",
-      "ts-node": "10.9.2",
+      "tsx": "4.22.4",
       "typescript": "5.5.4",
     },
     "license": "Apache-2.0",
@@ -1245,9 +1245,9 @@ CHANGELOG.md
         "version": "0.86.5",
       },
       {
-        "name": "ts-node",
+        "name": "tsx",
         "type": "build",
-        "version": "10.9.2",
+        "version": "4.22.4",
       },
       {
         "name": "typescript",
@@ -1287,7 +1287,7 @@ CHANGELOG.md
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.ts",
+            "exec": "tsx .projenrc.ts",
           },
         ],
       },
@@ -1340,7 +1340,7 @@ module.exports = {
       "@langri-sha/tsconfig": "*",
       "beachball": "2.65.5",
       "projen": "0.86.5",
-      "ts-node": "10.9.2",
+      "tsx": "4.22.4",
       "typescript": "5.5.4",
     },
     "license": "Apache-2.0",
@@ -1437,9 +1437,9 @@ node_modules/
         "version": "0.86.5",
       },
       {
-        "name": "ts-node",
+        "name": "tsx",
         "type": "build",
-        "version": "10.9.2",
+        "version": "4.22.4",
       },
       {
         "name": "typescript",
@@ -1468,7 +1468,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -1511,7 +1511,7 @@ export default [...defaults, {"ignores":["**/.*","**/dist/","!.projenrc.mts"]}]"
       "@langri-sha/projen-project": "*",
       "@langri-sha/tsconfig": "*",
       "projen": "0.86.5",
-      "ts-node": "10.9.2",
+      "tsx": "4.22.4",
       "typescript": "5.5.4",
     },
     "license": "Apache-2.0",
@@ -1608,7 +1608,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.ts",
+            "exec": "tsx .projenrc.ts",
           },
         ],
       },
@@ -1747,7 +1747,7 @@ dist/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -1854,7 +1854,7 @@ lint-staged
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -1976,7 +1976,7 @@ tsconfig*.json
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -2084,7 +2084,7 @@ dist/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -2185,7 +2185,7 @@ dist/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -2301,7 +2301,7 @@ pnpm-lock.yaml
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.ts",
+            "exec": "tsx .projenrc.ts",
           },
         ],
       },
@@ -2419,7 +2419,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -2615,7 +2615,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -2709,9 +2709,9 @@ node_modules/
         "version": "0.86.5",
       },
       {
-        "name": "ts-node",
+        "name": "tsx",
         "type": "build",
-        "version": "10.9.2",
+        "version": "4.22.4",
       },
       {
         "name": "typescript",
@@ -2739,7 +2739,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -2779,7 +2779,7 @@ node_modules/
       "@langri-sha/projen-project": "*",
       "@langri-sha/tsconfig": "*",
       "projen": "0.86.5",
-      "ts-node": "10.9.2",
+      "tsx": "4.22.4",
       "typescript": "5.5.4",
     },
     "license": "Apache-2.0",
@@ -3033,9 +3033,9 @@ node_modules/
         "version": "0.86.5",
       },
       {
-        "name": "ts-node",
+        "name": "tsx",
         "type": "build",
-        "version": "10.9.2",
+        "version": "4.22.4",
       },
       {
         "name": "typescript",
@@ -3063,7 +3063,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -3103,7 +3103,7 @@ node_modules/
       "@langri-sha/projen-project": "*",
       "@langri-sha/tsconfig": "*",
       "projen": "0.86.5",
-      "ts-node": "10.9.2",
+      "tsx": "4.22.4",
       "typescript": "5.5.4",
     },
     "license": "Apache-2.0",
@@ -3225,7 +3225,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },
@@ -3358,7 +3358,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.mts",
+            "exec": "tsx .projenrc.mts",
           },
         ],
       },

--- a/packages/projen-project/src/index.ts
+++ b/packages/projen-project/src/index.ts
@@ -711,7 +711,7 @@ export class Project extends BaseProject {
       this.package?.addDevDeps('typescript@5.5.4')
 
       if (!swcrc) {
-        this.package?.addDevDeps('ts-node@10.9.2')
+        this.package?.addDevDeps('tsx@4.22.4')
       }
     }
 

--- a/packages/projen-project/src/lib/__snapshots__/projenrc.test.ts.snap
+++ b/packages/projen-project/src/lib/__snapshots__/projenrc.test.ts.snap
@@ -59,7 +59,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projerc.ts",
+            "exec": "tsx .projerc.ts",
           },
         ],
       },
@@ -161,7 +161,7 @@ node_modules/
         "name": "default",
         "steps": [
           {
-            "exec": "node --loader ts-node/esm/transpile-only .projenrc.ts",
+            "exec": "tsx .projenrc.ts",
           },
         ],
       },

--- a/packages/projen-project/src/lib/projenrc.ts
+++ b/packages/projen-project/src/lib/projenrc.ts
@@ -25,9 +25,7 @@ export class ProjenrcFile extends BaseProjenrcFile {
 
     this.filePath = filename
 
-    this.project.defaultTask?.exec(
-      `node --loader ts-node/esm/transpile-only ${filename}`,
-    )
+    this.project.defaultTask?.exec(`tsx ${filename}`)
 
     new SampleFile(project, filename, {
       contents: `import { Project } from '@langri-sha/projen-project'

--- a/packages/projen-renovate/.projen/deps.json
+++ b/packages/projen-renovate/.projen/deps.json
@@ -16,6 +16,11 @@
       "type": "build"
     },
     {
+      "name": "tsx",
+      "version": "4.22.4",
+      "type": "build"
+    },
+    {
       "name": "projen",
       "version": "^0.86.0",
       "type": "peer"

--- a/packages/projen-renovate/package.json
+++ b/packages/projen-renovate/package.json
@@ -19,13 +19,14 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "prepare": "NODE_OPTIONS=\"--loader ts-node/esm/transpile-only\" schemastore-to-typescript renovate src/renovate.d.ts",
+    "prepare": "tsx ./node_modules/@langri-sha/schemastore-to-typescript/src/cli.ts renovate src/renovate.d.ts",
     "prepublishOnly": "rm -rf dist; tsc --project tsconfig.build.json"
   },
   "devDependencies": {
     "@langri-sha/schemastore-to-typescript": "workspace:*",
     "@langri-sha/tsconfig": "workspace:*",
-    "@langri-sha/vitest": "workspace:*"
+    "@langri-sha/vitest": "workspace:*",
+    "tsx": "4.22.4"
   },
   "peerDependencies": {
     "projen": "^0.86.0"

--- a/packages/projen-swcrc/.projen/deps.json
+++ b/packages/projen-swcrc/.projen/deps.json
@@ -16,6 +16,11 @@
       "type": "build"
     },
     {
+      "name": "tsx",
+      "version": "4.22.4",
+      "type": "build"
+    },
+    {
       "name": "@swc/core",
       "version": "^1.6.0",
       "type": "peer"

--- a/packages/projen-swcrc/package.json
+++ b/packages/projen-swcrc/package.json
@@ -19,13 +19,14 @@
   "type": "module",
   "main": "src/index.ts",
   "scripts": {
-    "prepare": "NODE_OPTIONS=\"--loader ts-node/esm/transpile-only\" schemastore-to-typescript swcrc src/swcrc.d.ts",
+    "prepare": "tsx ./node_modules/@langri-sha/schemastore-to-typescript/src/cli.ts swcrc src/swcrc.d.ts",
     "prepublishOnly": "rm -rf dist; tsc --project tsconfig.build.json"
   },
   "devDependencies": {
     "@langri-sha/schemastore-to-typescript": "workspace:*",
     "@langri-sha/tsconfig": "workspace:*",
-    "@langri-sha/vitest": "workspace:*"
+    "@langri-sha/vitest": "workspace:*",
+    "tsx": "4.22.4"
   },
   "peerDependencies": {
     "@swc/core": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,9 @@ importers:
       projen:
         specifier: 0.86.5
         version: 0.86.5(constructs@10.3.0)
-      ts-node:
-        specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.13.3)(@types/node@20.19.20)(typescript@5.5.4)
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -651,9 +651,9 @@ importers:
       ramda:
         specifier: 0.30.1
         version: 0.30.1
-      ts-node:
-        specifier: ^10.0.0
-        version: 10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.5))(@types/node@20.19.20)(typescript@5.5.2)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.22.4
       typescript:
         specifier: ^5.5.0
         version: 5.5.2
@@ -696,6 +696,9 @@ importers:
       '@langri-sha/vitest':
         specifier: workspace:*
         version: link:../vitest
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
 
   packages/projen-swcrc:
     dependencies:
@@ -715,6 +718,9 @@ importers:
       '@langri-sha/vitest':
         specifier: workspace:*
         version: link:../vitest
+      tsx:
+        specifier: 4.22.4
+        version: 4.22.4
 
   packages/projen-typescript-config:
     dependencies:
@@ -1850,9 +1856,21 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -1862,9 +1880,21 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -1874,9 +1904,21 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -1886,9 +1928,21 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -1898,9 +1952,21 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -1910,9 +1976,21 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -1922,9 +2000,21 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -1934,9 +2024,21 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -1946,11 +2048,35 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.21.5':
     resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-x64@0.21.5':
     resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
@@ -1958,9 +2084,27 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.21.5':
     resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -1970,15 +2114,33 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.21.5':
     resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -4071,6 +4233,11 @@ packages:
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
     hasBin: true
 
   escalade@3.1.1:
@@ -6615,6 +6782,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tsyringe@4.10.0:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
     engines: {node: '>= 6.0.0'}
@@ -8364,6 +8536,7 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    optional: true
 
   '@discoveryjs/json-ext@0.5.7': {}
 
@@ -8509,70 +8682,148 @@ snapshots:
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
   '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
     optional: true
 
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
   '@esbuild/win32-ia32@0.21.5':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.0(eslint@9.2.0)':
@@ -8922,6 +9173,7 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.1
       '@jridgewell/sourcemap-codec': 1.4.15
+    optional: true
 
   '@jsdevtools/ono@7.1.3': {}
 
@@ -9426,13 +9678,17 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  '@tsconfig/node10@1.0.11': {}
+  '@tsconfig/node10@1.0.11':
+    optional: true
 
-  '@tsconfig/node12@1.0.11': {}
+  '@tsconfig/node12@1.0.11':
+    optional: true
 
-  '@tsconfig/node14@1.0.3': {}
+  '@tsconfig/node14@1.0.3':
+    optional: true
 
-  '@tsconfig/node16@1.0.4': {}
+  '@tsconfig/node16@1.0.4':
+    optional: true
 
   '@tybys/wasm-util@0.10.0':
     dependencies:
@@ -9984,7 +10240,8 @@ snapshots:
 
   are-docs-informative@0.0.2: {}
 
-  arg@4.1.3: {}
+  arg@4.1.3:
+    optional: true
 
   argparse@1.0.10:
     dependencies:
@@ -10608,7 +10865,8 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-require@1.1.1: {}
+  create-require@1.1.1:
+    optional: true
 
   critters@0.0.25:
     dependencies:
@@ -10764,7 +11022,8 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.2: {}
+  diff@4.0.2:
+    optional: true
 
   dir-glob@3.0.1:
     dependencies:
@@ -10999,6 +11258,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   escalade@3.1.1: {}
 
@@ -12773,7 +13061,8 @@ snapshots:
     dependencies:
       semver: 7.7.4
 
-  make-error@1.3.6: {}
+  make-error@1.3.6:
+    optional: true
 
   makeerror@1.0.12:
     dependencies:
@@ -14044,6 +14333,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.13.3
+    optional: true
 
   ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.5))(@types/node@20.19.20)(typescript@5.5.2):
     dependencies:
@@ -14064,6 +14354,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.6.13(@swc/helpers@0.5.5)
+    optional: true
 
   ts-toolbelt@9.6.0: {}
 
@@ -14079,6 +14370,12 @@ snapshots:
   tslib@2.6.3: {}
 
   tslib@2.8.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tsyringe@4.10.0:
     dependencies:
@@ -14218,7 +14515,8 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  v8-compile-cache-lib@3.0.1: {}
+  v8-compile-cache-lib@3.0.1:
+    optional: true
 
   v8-to-istanbul@9.2.0:
     dependencies:
@@ -14657,7 +14955,8 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yn@3.1.1: {}
+  yn@3.1.1:
+    optional: true
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
## Summary

Bumping `langri-sha/github/.github/workflows/check.yml` to `v0.9.0` defaulted CI to **Node 24**, where the deprecated `--loader ts-node/esm/transpile-only` flag no longer works. This broke the Renovate post-upgrade job's `install:ci` chain (both package `prepare` scripts and the projenrc synthesis task failed with exit 13).

This migrates all three call sites of the loader to [`tsx`](https://tsx.is), the maintained Node 20/22/24-compatible TypeScript executor.

## Changes

- **`@langri-sha/projen-project`** — `ProjenrcFile` now emits `tsx <projenrc>` as the default synthesis task (was `node --loader ts-node/esm/transpile-only <projenrc>`).
- **`@langri-sha/projen-renovate`** / **`@langri-sha/projen-swcrc`** — the `prepare` scripts now run the `schemastore-to-typescript` CLI through `tsx`.
- Swapped the `ts-node` devDep/peerDep for `tsx@4.22.4` wherever it served as the runner (root project, `projen-project` optional peer, and the two `prepare`-script packages). `ts-node` now only remains in the lockfile as jest's optional peer.
- Regenerated the projen-managed files (`.projen/*`, generated `package.json`s) and the `projen-project` vitest snapshots; added `patch` beachball change files for the three published packages.

### Note on the prepare-script pattern

The issue suggested `tsx ./node_modules/.bin/<bin> …`, but pnpm materializes `.bin` entries as POSIX shell shims (`#!/bin/sh … exec node …`), which `tsx` cannot parse as TypeScript. The scripts therefore point `tsx` at the CLI's resolved source entry instead:

```
tsx ./node_modules/@langri-sha/schemastore-to-typescript/src/cli.ts renovate src/renovate.d.ts
```

## Test plan

- [x] `rm -rf node_modules && pnpm install` (cold cache, Node 25) — both `prepare` scripts run cleanly with no `--loader` warnings.
- [x] `pnpm projen` — synth completes end-to-end and is idempotent (no diff on re-run).
- [x] `vitest run` — full workspace suite green (132 passed, 4 skipped).
- [x] `eslint`, `tsc -b`, `prettier --check` — clean.
- [x] `beachball check` — passes with the new change files.

Closes #1046
