### PR TITLE
Update langri-sha/github to v0.10.1 and pin Terraform to 1.9.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: langri-sha/github/.github/workflows/packages.yml@v0.8.0
+    uses: langri-sha/github/.github/workflows/packages.yml@v0.10.1
     with:
       environment: release
       scope: '@langri-sha'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -33,6 +33,6 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run checks
-        uses: langri-sha/github/actions/terraform@v0.7.2
+        uses: langri-sha/github/actions/terraform@v0.10.1
         with:
           working-directory: ${{ matrix.working-directory }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -35,4 +35,5 @@ jobs:
       - name: Run checks
         uses: langri-sha/github/actions/terraform@v0.10.1
         with:
+          terraform-version: 1.9.5
           working-directory: ${{ matrix.working-directory }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup PNPM
-        uses: langri-sha/github/actions/pnpm@v0.7.2
+        uses: langri-sha/github/actions/pnpm@v0.10.1
 
       - name: Build
         run: pnpm build
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Google Cloud Platform
-        uses: langri-sha/github/actions/google-cloud-platform@v0.7.2
+        uses: langri-sha/github/actions/google-cloud-platform@v0.10.1
         with:
           service_account: ${{ vars.SERVICE_ACCOUNT }}
           setup_gcloud: true

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    uses: langri-sha/github/.github/workflows/check.yml@v0.9.0
+    uses: langri-sha/github/.github/workflows/check.yml@v0.10.1
     with:
       beachball: true
       eslint: true


### PR DESCRIPTION
Manual replacement for Renovate's upgrade PR. Renovate bumps the version
references but cannot add the new `terraform-version` input that v0.10.1
needs, so the Terraform job keeps failing. This PR does both.

## Changes

- **`.github/workflows/workspace.yml`** — `check.yml` reusable workflow `@v0.9.0` → `@v0.10.1`
- **`.github/workflows/publish.yml`** — `packages.yml` reusable workflow `@v0.8.0` → `@v0.10.1`
- **`.github/workflows/web.yml`** — `actions/pnpm` and `actions/google-cloud-platform` `@v0.7.2` → `@v0.10.1`
- **`.github/workflows/terraform.yml`** — `actions/terraform` `@v0.7.2` → `@v0.10.1`, plus a new `terraform-version: 1.9.5` input

## Why the Terraform input

The `actions/terraform` composite action auto-detects the Terraform version from
`required_version` in the `*.tf` files, but that detection silently fails on the
runner and installs the latest Terraform (1.15.5), which breaks our
`required_version = "1.9.5"` pin. v0.10.1 adds a `terraform-version` input
([langri-sha/github#47](https://github.com/langri-sha/github/pull/47)) that takes
precedence over the auto-detection; pinning it to `1.9.5` matches the configuration.

## Test plan

- [ ] Workspace check workflow runs green on the bumped `check.yml@v0.10.1`.
- [ ] Web build + deploy jobs run green on the bumped `pnpm`/`google-cloud-platform` actions.
- [ ] Terraform `validate` matrix installs Terraform 1.9.5 (not latest) and passes `fmt`/`init`/`validate` for both `terraform/web` and `terraform/org`.
- [ ] Release/packages workflow unaffected by the `packages.yml@v0.10.1` bump (dispatch-only; verified on next release).

Reference: https://github.com/langri-sha/github/releases/tag/v0.10.1

Closes #1049