### PR TITLE
fix(schemastore-to-typescript): force CLI exit after argument parsing

### DIFF
--- a/change/@langri-sha-schemastore-to-typescript-283bca63-6b7e-454e-a732-4f78dd3843cb.json
+++ b/change/@langri-sha-schemastore-to-typescript-283bca63-6b7e-454e-a732-4f78dd3843cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Force CLI exit so a lingering handle cannot hang the runtime on nested re-runs",
+  "packageName": "@langri-sha/schemastore-to-typescript",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/schemastore-to-typescript/src/cli.ts
+++ b/packages/schemastore-to-typescript/src/cli.ts
@@ -31,5 +31,13 @@ export const program: Command = new Command()
 
 if (esMain(import.meta)) {
   debug('Parsing arguments', process.argv)
-  await program.parseAsync(process.argv)
+  try {
+    await program.parseAsync(process.argv)
+  } catch (error) {
+    console.error(error)
+    process.exitCode = 1
+  } finally {
+    // Force exit so a lingering handle can't hang the runtime on nested re-runs.
+    process.exit(process.exitCode ?? 0)
+  }
 }


### PR DESCRIPTION
## Bug

`packages/schemastore-to-typescript/src/cli.ts` ran a bare top-level
`await program.parseAsync(process.argv)`. The promise could resolve while an
open handle kept the event loop alive. On the first install pass this was
harmless, but when projen's nested `installDependencies()` re-runs the `tsx`
prepare scripts, Node logged `Warning: Detected unsettled top-level await` and
was killed with **exit 13**.

That cascaded into `Synthesis failed: Task "default" failed when executing
"tsx .projenrc.ts"` and broke the Renovate post-upgrade chain in `check.yml`
for any PR bumping a dep on the swc/projen synthesis path.

See the failing post-upgrade on PR #1048 (swc monorepo update),
run 2026-06-01:
https://github.com/langri-sha/langri-sha.com/actions/runs/26770619303
(search the log for `unsettled top-level await`).

## Fix

Wrap the entry-point parse in `try / catch / finally` and force-exit via
`process.exit()` so a lingering handle can no longer hang the runtime on the
nested re-run. Parse errors now set exit code 1; the success path exits 0.

## Test plan

- `pnpm install` — both `packages/projen-{swcrc,renovate} prepare: Done` with
  no `unsettled top-level await` warnings.
- `pnpm projen` — synthesis completes (exercises the nested install where the
  bug originally bit); no errors or warnings.
- `pnpm vitest run src/cli.test.ts` — 5/5 pass.

Helps #1048
