### PR TITLE
Keep Terraform CI workflow pin in sync with version

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -6,13 +6,13 @@ on:
       - main
     paths:
       - '.github/workflows/terraform.yml'
-      - '*.tf'
-      - '*.lock.hcl'
+      - '**/*.tf'
+      - '**/*.lock.hcl'
   pull_request:
     paths:
       - '.github/workflows/terraform.yml'
-      - '*.tf'
-      - '*.lock.hcl'
+      - '**/*.tf'
+      - '**/*.lock.hcl'
 
 jobs:
   validate:

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -90,6 +90,22 @@ const project = new Project({
         matchPackageNames: ['hashicorp/google*'],
       },
     ],
+    customManagers: [
+      {
+        // Keep the Terraform CI workflow pin in lockstep with `required_version`.
+        // The `langri-sha/github` terraform action installs latest when version
+        // auto-detection fails, so `terraform-version` must track the configured
+        // Terraform release. Matching depName/datasource/versioning to the built-in
+        // `required_version` manager lands this on the same Renovate branch as the
+        // Dockerfile and `versions.tf` bumps.
+        customType: 'regex',
+        datasourceTemplate: 'github-releases',
+        depNameTemplate: 'hashicorp/terraform',
+        versioningTemplate: 'hashicorp',
+        managerFilePatterns: ['/^\\.github/workflows/terraform\\.yml$/'],
+        matchStrings: ['terraform-version:\\s*(?<currentValue>\\S+)'],
+      },
+    ],
   },
   swcrc: {},
   typeScriptConfig: {

--- a/renovate.json5
+++ b/renovate.json5
@@ -72,5 +72,13 @@
       depNameTemplate: 'pnpm',
       depTypeTemplate: 'dependencies',
     },
+    {
+      customType: 'regex',
+      datasourceTemplate: 'github-releases',
+      depNameTemplate: 'hashicorp/terraform',
+      versioningTemplate: 'hashicorp',
+      managerFilePatterns: ['/^\\.github/workflows/terraform\\.yml$/'],
+      matchStrings: ['terraform-version:\\s*(?<currentValue>\\S+)'],
+    },
   ],
 }


### PR DESCRIPTION
## Summary

Renovate's `hashicorp/terraform` update bumped the version in `terraform/Dockerfile` and both `terraform/*/versions.tf` (`required_version`) but left `.github/workflows/terraform.yml`'s `terraform-version:` input behind. Because the `langri-sha/github` terraform action silently installs **latest** when version auto-detection fails, that input was pinned deliberately (`f6c4bf92`) and must move with `required_version` — otherwise CI fails with *"Unsupported Terraform Core version"* (which held back #1056, 1.9.5 → 1.15.5).

This teaches Renovate to bump the workflow pin in lockstep, and widens the workflow path filter so the validate job actually runs on these bumps.

## Changes

- **`.projenrc.ts`** — add a Renovate `customManagers` regex entry (datasource `github-releases`, depName `hashicorp/terraform`, versioning `hashicorp`) targeting `.github/workflows/terraform.yml`. Matching the depName/datasource/versioning of the built-in `required_version` manager lands the update on the same Renovate branch (`renovate/hashicorp-terraform-1.x`) as the Dockerfile and `versions.tf` bumps, so all four files move in one PR.
- **`renovate.json5`** — regenerated via `npx projen`; now contains the new customManager.
- **`.github/workflows/terraform.yml`** (bonus) — widen the `push`/`pull_request` path filter from the root-only globs `*.tf` / `*.lock.hcl` to `**/*.tf` / `**/*.lock.hcl` so the validate job triggers on nested `terraform/**/*.tf` changes and would catch a future version/pin mismatch.

## Test plan

- `npx projen` regenerates cleanly; `renovate.json5` contains the new customManager and no other config drifts.
- `renovate-config-validator renovate.json5` → *Config validated successfully*.
- The customManager regex `terraform-version:\s*(?<currentValue>\S+)` matches the pinned line in the workflow.
- On the next Terraform release, confirm Renovate's PR updates `terraform-version:` alongside the Dockerfile and `versions.tf`.

Closes #1066