### PR TITLE
Update shared workflow pin to v0.10.2

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    uses: langri-sha/github/.github/workflows/check.yml@v0.10.1
+    uses: langri-sha/github/.github/workflows/check.yml@v0.10.2
     with:
       beachball: true
       eslint: true


### PR DESCRIPTION
## Summary

- update the Workspace reusable workflow from `langri-sha/github@v0.10.1` to `v0.10.2`

## Why

`v0.10.2` contains the post-upgrade Beachball staging fix needed for Renovate formatter updates.

## Testing

- `git diff --check`
- commit hook / lint-staged