### PR TITLE
Migrate Next.js config to TypeScript

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,9 +1,6 @@
-// @ts-check
+import type { NextConfig } from 'next'
 
-/**
- * @type {import('next').NextConfig}
- **/
-const config = {
+const config: NextConfig = {
   assetPrefix: process.env.ASSETS_URL,
   distDir: 'dist',
   output: 'export',
@@ -24,4 +21,4 @@ const config = {
   },
 }
 
-module.exports = config
+export default config


### PR DESCRIPTION
## Summary

Migrates `apps/web/next.config.js` to `apps/web/next.config.ts`, taking
advantage of native TypeScript config support introduced in Next.js 15+ and
available in the Next.js 16 upgrade from #1092.

## Changes

- Deleted `apps/web/next.config.js` (CommonJS with `@ts-check` JSDoc types)
- Added `apps/web/next.config.ts` with a typed `import type { NextConfig } from 'next'`
- Replaced `module.exports = config` with `export default config`
- All config fields preserved identically: `assetPrefix`, `distDir`, `output`, `reactStrictMode`, `compiler.emotion`, `experimental.inlineCss`, `turbopack.rules`

## Test plan

- `pnpm --filter @langri-sha/web build` passes without errors
- TypeScript type-check (`tsc --noEmit`) passes with no errors
- Config is functionally identical; no runtime behavior changes