### PR TITLE
Fix schemastore CLI hang from unsettled top-level await

### DIFF
--- a/change/@langri-sha-schemastore-to-typescript-d24a4b88-c538-4636-9004-8fb172dea9e9.json
+++ b/change/@langri-sha-schemastore-to-typescript-d24a4b88-c538-4636-9004-8fb172dea9e9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Drive the CLI through `.then`/`.catch` instead of a top-level await so a stalled cache request can no longer hang `prepare` as an unsettled top-level await (exit code 13)",
+  "packageName": "@langri-sha/schemastore-to-typescript",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/schemastore-to-typescript/src/cli.ts
+++ b/packages/schemastore-to-typescript/src/cli.ts
@@ -31,11 +31,6 @@ export const program: Command = new Command()
 
 if (esMain(import.meta)) {
   debug('Parsing arguments', process.argv)
-  // Avoid top-level `await`: under tsx the cache layer can leave the request
-  // promise pending while the event loop drains, which Node reports as an
-  // unsettled top-level await (exit code 13) and hangs `prepare` in CI. Driving
-  // the parse through `.then`/`.catch` and forcing the exit keeps termination
-  // deterministic regardless of any lingering handle.
   program
     .parseAsync(process.argv)
     .then(() => {

--- a/packages/schemastore-to-typescript/src/cli.ts
+++ b/packages/schemastore-to-typescript/src/cli.ts
@@ -31,13 +31,18 @@ export const program: Command = new Command()
 
 if (esMain(import.meta)) {
   debug('Parsing arguments', process.argv)
-  try {
-    await program.parseAsync(process.argv)
-  } catch (error) {
-    console.error(error)
-    process.exitCode = 1
-  } finally {
-    // Force exit so a lingering handle can't hang the runtime on nested re-runs.
-    process.exit(process.exitCode ?? 0)
-  }
+  // Avoid top-level `await`: under tsx the cache layer can leave the request
+  // promise pending while the event loop drains, which Node reports as an
+  // unsettled top-level await (exit code 13) and hangs `prepare` in CI. Driving
+  // the parse through `.then`/`.catch` and forcing the exit keeps termination
+  // deterministic regardless of any lingering handle.
+  program
+    .parseAsync(process.argv)
+    .then(() => {
+      process.exit(0)
+    })
+    .catch((error) => {
+      console.error(error)
+      process.exit(1)
+    })
 }


### PR DESCRIPTION
## Summary

The `@langri-sha/schemastore-to-typescript` CLI intermittently hung and exited with code 13 during the projen `prepare` step, breaking the **Check projen configuration** job (e.g. [run 27446361915](https://github.com/langri-sha/langri-sha.com/actions/runs/27446361915/job/81132133106)).

## Root cause

`cli.ts` ran `await program.parseAsync(...)` as a **top-level await**. Under `tsx`, the `got` + `keyv` cache layer can leave that request promise pending while the event loop drains, which Node reports as an *unsettled top-level await* (`exit code 13`) at `cli.ts:35`. Because the `prepare` scripts in `projen-renovate` and `projen-swcrc` invoke this CLI during `pnpm i`, the synth (`install:ci`) failed.

The earlier `finally { process.exit() }` guard could not help: `finally` only runs once the awaited promise settles, and here it never does.

## Changes

- Drive `program.parseAsync` through `.then`/`.catch` instead of a top-level `await`, removing the unsettled-top-level-await failure mode and forcing a deterministic `process.exit(0)` on success / `process.exit(1)` on error.
- Add a Beachball change file (patch) for the published package.

## Test plan

- `pnpm --filter @langri-sha/schemastore-to-typescript exec vitest run` — 13/13 pass.
- Ran the CLI directly with a **cold cache** (`renovate` + `swcrc`), including concurrent invocations mirroring CI's two `prepare` scripts — exits 0 and writes the definition files every time.
- `pnpm projen` from a cold cache now exits 0 with no resulting git diff (the previously failing step).
- ESLint + Prettier clean on the change.