### PR TITLE
Drop change files for packages now published from langri-sha/projen

### DIFF
--- a/change/@langri-sha-projen-eslint-713b8611-9f9a-49d3-9640-cb56194dfe31.json
+++ b/change/@langri-sha-projen-eslint-713b8611-9f9a-49d3-9640-cb56194dfe31.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore: widen eslint peer dependency range to ^9.0.0 || ^10.0.0",
-  "packageName": "@langri-sha/projen-eslint",
-  "email": "filip.dupanovic@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-husky-3ea9f9ad-91ed-45de-9e41-367ffbdb97ee.json
+++ b/change/@langri-sha-projen-husky-3ea9f9ad-91ed-45de-9e41-367ffbdb97ee.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore(deps): update dependency @types/node to v20.19.41",
-  "packageName": "@langri-sha/projen-husky",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-husky-dace640e-c86b-48ac-b3db-f3a378c07cd0.json
+++ b/change/@langri-sha-projen-husky-dace640e-c86b-48ac-b3db-f3a378c07cd0.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Update @types/node to 24.13.2",
-  "packageName": "@langri-sha/projen-husky",
-  "email": "filip.dupanovic@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-lint-synthesized-87269882-448e-43a3-88b0-39472cbdafb2.json
+++ b/change/@langri-sha-projen-lint-synthesized-87269882-448e-43a3-88b0-39472cbdafb2.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix(deps): update dependency debug to v4.4.3",
-  "packageName": "@langri-sha/projen-lint-synthesized",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-lint-synthesized-8ffb5f0b-5f4e-4dbf-9349-838256db6455.json
+++ b/change/@langri-sha-projen-lint-synthesized-8ffb5f0b-5f4e-4dbf-9349-838256db6455.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore(deps): update dependency prettier to v3.8.3",
-  "packageName": "@langri-sha/projen-lint-synthesized",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-lint-synthesized-a139de3d-2fa0-4079-aa3d-2764981fff0a.json
+++ b/change/@langri-sha-projen-lint-synthesized-a139de3d-2fa0-4079-aa3d-2764981fff0a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix(deps): update dependency minimatch to v10.2.5",
-  "packageName": "@langri-sha/projen-lint-synthesized",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-pnpm-workspace-5e1f9832-c906-41c5-a4f5-0e586d9bc13b.json
+++ b/change/@langri-sha-projen-pnpm-workspace-5e1f9832-c906-41c5-a4f5-0e586d9bc13b.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix(deps): update dependency yaml to v2.9.0",
-  "packageName": "@langri-sha/projen-pnpm-workspace",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-prettier-2e103618-31fe-4d14-ae7c-17f11bc94d7f.json
+++ b/change/@langri-sha-projen-prettier-2e103618-31fe-4d14-ae7c-17f11bc94d7f.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix(deps): align prettier package dev dependencies",
-  "packageName": "@langri-sha/projen-prettier",
-  "email": "filip.dupanovic@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-project-115f211e-2529-4b5b-8b62-0f68a558daf7.json
+++ b/change/@langri-sha-projen-project-115f211e-2529-4b5b-8b62-0f68a558daf7.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Migrate from the deprecated ts-node ESM loader to tsx for Node 24 compatibility",
-  "packageName": "@langri-sha/projen-project",
-  "email": "filip.dupanovic@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-project-3c8b6231-be66-4ccb-a7f7-ba17fcde6cd2.json
+++ b/change/@langri-sha-projen-project-3c8b6231-be66-4ccb-a7f7-ba17fcde6cd2.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix(deps): update dependency ramda to v0.32.0",
-  "packageName": "@langri-sha/projen-project",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-project-432e70e1-88fb-42ed-8b96-5f79053f0348.json
+++ b/change/@langri-sha-projen-project-432e70e1-88fb-42ed-8b96-5f79053f0348.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore(deps): update dependency typescript to v5.9.3",
-  "packageName": "@langri-sha/projen-project",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-project-8e59b6e4-1631-407b-b7f9-1fcaf687a504.json
+++ b/change/@langri-sha-projen-project-8e59b6e4-1631-407b-b7f9-1fcaf687a504.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore(deps): update dependency beachball to v2.65.4",
-  "packageName": "@langri-sha/projen-project",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-project-984b6a88-6242-4e86-8f87-8ce8266fb26e.json
+++ b/change/@langri-sha-projen-project-984b6a88-6242-4e86-8f87-8ce8266fb26e.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore: widen eslint peer dependency range to ^9.0.0 || ^10.0.0",
-  "packageName": "@langri-sha/projen-project",
-  "email": "filip.dupanovic@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-project-c6ce01e6-e6df-4bd4-af47-a2a66569b1c5.json
+++ b/change/@langri-sha-projen-project-c6ce01e6-e6df-4bd4-af47-a2a66569b1c5.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore(deps): update dependency prettier to v3.8.3",
-  "packageName": "@langri-sha/projen-project",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-project-dac0df70-41b8-482c-bfcc-0e0eb81ee680.json
+++ b/change/@langri-sha-projen-project-dac0df70-41b8-482c-bfcc-0e0eb81ee680.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore(deps): update dependency beachball to v2.65.5",
-  "packageName": "@langri-sha/projen-project",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-project-dd753fee-f423-46a4-804a-82b26f0ffa40.json
+++ b/change/@langri-sha-projen-project-dd753fee-f423-46a4-804a-82b26f0ffa40.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore(deps): update swc monorepo",
-  "packageName": "@langri-sha/projen-project",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-renovate-bdf897fe-2eba-47d9-a034-85ab4cb9d05b.json
+++ b/change/@langri-sha-projen-renovate-bdf897fe-2eba-47d9-a034-85ab4cb9d05b.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Migrate from the deprecated ts-node ESM loader to tsx for Node 24 compatibility",
-  "packageName": "@langri-sha/projen-renovate",
-  "email": "filip.dupanovic@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-swcrc-0e0eb805-7ab1-47d5-8eb0-9a7800a67538.json
+++ b/change/@langri-sha-projen-swcrc-0e0eb805-7ab1-47d5-8eb0-9a7800a67538.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Migrate from the deprecated ts-node ESM loader to tsx for Node 24 compatibility",
-  "packageName": "@langri-sha/projen-swcrc",
-  "email": "filip.dupanovic@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-typescript-config-60f0111c-f3ae-4467-93a6-f8147d61c4f2.json
+++ b/change/@langri-sha-projen-typescript-config-60f0111c-f3ae-4467-93a6-f8147d61c4f2.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Update @types/node to 24.13.2",
-  "packageName": "@langri-sha/projen-typescript-config",
-  "email": "filip.dupanovic@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-projen-typescript-config-f952f725-e997-4947-b51e-54c6e25688cc.json
+++ b/change/@langri-sha-projen-typescript-config-f952f725-e997-4947-b51e-54c6e25688cc.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore(deps): update dependency @types/node to v20.19.41",
-  "packageName": "@langri-sha/projen-typescript-config",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}


### PR DESCRIPTION
## Summary

Removes the 20 pending beachball change files for the `@langri-sha/projen-*` packages. Those packages now live in and publish from **[langri-sha/projen](https://github.com/langri-sha/projen)** — the change files were ported there in langri-sha/projen#1. Leaving them here would let this repo publish competing versions of the same packages. Removing them stops langri-sha.com from bumping/publishing them.

## Changes

- Delete 20 change files under `change/` for 9 packages: `projen-eslint`, `projen-husky`, `projen-lint-synthesized`, `projen-pnpm-workspace`, `projen-prettier`, `projen-project`, `projen-renovate`, `projen-swcrc`, `projen-typescript-config`.
- The 38 change files for packages that still live here are untouched.

## Follow-up (out of scope)

This stops *new* releases of these packages from this repo, but the `packages/projen-*` directories still exist here and are still publishable. Full decommission of the legacy publishing origin means removing those package directories (or marking them private) in a later change.

## Test plan

- `beachball check` → exit 0, "No change files are needed" (a deletion needs no change file).
