### PR TITLE
Homepage redesign: Neon Noir

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 }
 
 export const viewport: Viewport = {
-  themeColor: '#333',
+  themeColor: '#06030a',
 }
 
 export default function RootLayout({

--- a/apps/web/src/app/lib/header/index.tsx
+++ b/apps/web/src/app/lib/header/index.tsx
@@ -1,3 +1,4 @@
+import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as React from 'react'
 
@@ -52,18 +53,46 @@ export const Header: React.FC = () => (
 )
 
 const Root = styled.header`
-  ${animations.booming};
   ${layers.foreground};
   position: relative;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+`
+
+// The masthead's steady, lit state — a tight magenta bloom with a cooler mist rim.
+const neonGlow = `
+  0 0 0.4rem rgba(255, 217, 249, 0.9),
+  0 0 1.2rem rgba(228, 56, 220, 0.85),
+  0 0 2.4rem rgba(228, 56, 220, 0.6),
+  0 0 4.6rem rgba(228, 56, 220, 0.35),
+  0 0 6.4rem rgba(121, 172, 187, 0.32)
+`
+
+// Power-on: a couple of stutters, then the sign holds.
+const powerOn = keyframes`
+  0%, 8% { opacity: 0; }
+  9% { opacity: 0.85; }
+  10% { opacity: 0.1; }
+  12% { opacity: 0.9; }
+  14% { opacity: 0.15; }
+  22% { opacity: 1; }
+  24% { opacity: 0.35; }
+  26% { opacity: 1; }
+  30% { opacity: 0.55; }
+  32%, 100% { opacity: 1; }
 `
 
 const Title = styled.h1`
   ${fonts.heading};
-  color: ${colors.text};
+  color: ${colors.neonCore};
   font-size: 6rem;
   letter-spacing: -0.03em;
   margin-top: 0;
+  margin-bottom: 0;
   user-select: none;
+  text-shadow: ${neonGlow};
+  animation: ${powerOn} 2.2s linear both;
 
   ${media.medium} {
     font-size: 8rem;
@@ -72,22 +101,63 @@ const Title = styled.h1`
   ${media.large} {
     font-size: 10rem;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 `
 
 const Nav = styled.nav`
+  ${animations.booming};
   display: flex;
   width: 100%;
   left: 0;
+  margin-top: 3rem;
   flex-flow: row nowrap;
   align-items: center;
   justify-content: center;
+  animation-delay: 0.6s;
+  animation-fill-mode: backwards;
+
+  ${media.medium} {
+    margin-top: 4rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 `
 
 const Link = styled.a`
-  color: ${colors.text};
+  display: inline-flex;
+  color: ${colors.mist};
   font-size: 3.2rem;
   text-decoration: none;
   margin: 1rem;
+  border-radius: 0.4rem;
+  opacity: 0.4;
+  filter: saturate(0.7);
+  transition:
+    opacity 250ms ease-out,
+    transform 250ms ease-out,
+    filter 250ms ease-out,
+    color 250ms ease-out;
+
+  &:hover {
+    color: ${colors.neonCore};
+    opacity: 1;
+    transform: scale(1.14);
+    filter: saturate(1) drop-shadow(0 0 0.6rem ${colors.magenta})
+      drop-shadow(0 0 1.4rem rgba(228, 56, 220, 0.7));
+  }
+
+  &:focus-visible {
+    color: ${colors.neonCore};
+    opacity: 1;
+    outline: 2px solid ${colors.magenta};
+    outline-offset: 6px;
+    filter: saturate(1) drop-shadow(0 0 0.7rem ${colors.magenta});
+  }
 
   ${media.medium} {
     font-size: 4.8rem;
@@ -95,5 +165,13 @@ const Link = styled.a`
 
   ${media.large} {
     font-size: 6.4rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+
+    &:hover {
+      transform: none;
+    }
   }
 `

--- a/apps/web/src/app/lib/landing.tsx
+++ b/apps/web/src/app/lib/landing.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled'
 import * as React from 'react'
 
 import { Drone, Play, Scene } from '@/components'
-import { global } from '@/styles'
+import { colors, global } from '@/styles'
 
 import { Header } from './header'
 
@@ -15,212 +15,174 @@ export const Landing: React.FC = () => {
 
   return (
     <React.Fragment>
-      <Global styles={[global, gradientProperties]} />
-      <Root>
-        <Root>
-          <Header />
-          {process.env.EXPERIMENTAL_SCENE ? <Scene /> : null}
-          {playing ? <Drone /> : null}
-          <Play
-            playing={playing}
-            onToggle={() => setPlaying((current) => !current)}
-          />
-        </Root>
-      </Root>
+      <Global styles={[global, nebulaProperties]} />
+      <Ground data-playing={playing}>
+        <Header />
+        {process.env.EXPERIMENTAL_SCENE ? <Scene /> : null}
+        {playing ? <Drone /> : null}
+        <Play
+          playing={playing}
+          onToggle={() => setPlaying((current) => !current)}
+        />
+      </Ground>
     </React.Fragment>
   )
 }
 
-const gradientProperties = css`
-  /* Aurora */
-  @property --aurora-x {
+// Registered custom props let the nebula's colour and position tween smoothly.
+const nebulaProperties = css`
+  @property --neb-x {
     syntax: '<percentage>';
     inherits: true;
-    initial-value: 0%;
+    initial-value: 32%;
   }
 
-  @property --aurora-y {
+  @property --neb-y {
     syntax: '<percentage>';
     inherits: true;
-    initial-value: 0%;
+    initial-value: 30%;
   }
 
-  @property --aurora-rx {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 140%;
-  }
-
-  @property --aurora-ry {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 140%;
-  }
-
-  /* Pool */
   @property --pool-x {
     syntax: '<percentage>';
     inherits: true;
-    initial-value: 60%;
+    initial-value: 70%;
   }
 
   @property --pool-y {
     syntax: '<percentage>';
     inherits: true;
-    initial-value: 50%;
+    initial-value: 68%;
   }
 
-  @property --pool-stop {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 20%;
-  }
-
-  /* Palette */
-  @property --violet {
+  @property --nebula-violet {
     syntax: '<color>';
     inherits: true;
     initial-value: #3d1b6d;
   }
 
-  @property --magenta {
+  @property --nebula-magenta {
     syntax: '<color>';
     inherits: true;
     initial-value: #e438dc;
   }
-
-  @property --indigo {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #404b8c;
-  }
-
-  @property --mist {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #79acbb;
-  }
-
-  @property --pool {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #7f4dad;
-  }
 `
 
+// A very slow, sleepy drift — the room is alive but barely.
 const drift = keyframes`
   0% {
-    --aurora-x: 0%;
-    --aurora-y: 0%;
-    --aurora-rx: 140%;
-    --aurora-ry: 140%;
-    --pool-x: 60%;
-    --pool-y: 50%;
-    --pool-stop: 20%;
-    --violet: #3d1b6d;
-    --magenta: #e438dc;
-    --indigo: #404b8c;
-    --mist: #79acbb;
-    --pool: #7f4dad;
+    --neb-x: 32%;
+    --neb-y: 30%;
+    --pool-x: 70%;
+    --pool-y: 68%;
+    --nebula-violet: #3d1b6d;
+    --nebula-magenta: #e438dc;
   }
 
-  33% {
-    --aurora-x: 12%;
-    --aurora-y: 8%;
-    --aurora-rx: 165%;
-    --aurora-ry: 120%;
-    --pool-x: 50%;
-    --pool-y: 42%;
-    --pool-stop: 32%;
-    --violet: #4a1a86;
-    --magenta: #ff2f92;
-    --indigo: #3d5bb0;
-    --mist: #4dd7e8;
-    --pool: #9a3df0;
-  }
-
-  66% {
-    --aurora-x: 4%;
-    --aurora-y: 18%;
-    --aurora-rx: 120%;
-    --aurora-ry: 170%;
-    --pool-x: 66%;
-    --pool-y: 58%;
-    --pool-stop: 26%;
-    --violet: #33206e;
-    --magenta: #c433ff;
-    --indigo: #4a3f9e;
-    --mist: #62b8d9;
-    --pool: #b03ddb;
+  50% {
+    --neb-x: 40%;
+    --neb-y: 24%;
+    --pool-x: 62%;
+    --pool-y: 74%;
+    --nebula-violet: #45228c;
+    --nebula-magenta: #c433ff;
   }
 
   100% {
-    --aurora-x: 16%;
-    --aurora-y: 4%;
-    --aurora-rx: 150%;
-    --aurora-ry: 135%;
-    --pool-x: 56%;
-    --pool-y: 48%;
-    --pool-stop: 22%;
-    --violet: #3d1b6d;
-    --magenta: #f038c8;
-    --indigo: #404b8c;
-    --mist: #79acbb;
-    --pool: #8748c4;
+    --neb-x: 28%;
+    --neb-y: 34%;
+    --pool-x: 74%;
+    --pool-y: 62%;
+    --nebula-violet: #33206e;
+    --nebula-magenta: #e438dc;
   }
 `
 
-const Root = styled.div`
+// While the drone plays, the room breathes a touch deeper — a gentle swell, not a flood.
+const breathe = keyframes`
+  from {
+    opacity: 0.18;
+  }
+
+  to {
+    opacity: 0.34;
+  }
+`
+
+const Ground = styled.div`
+  position: relative;
   display: flex;
+  overflow: hidden;
   height: 100vh;
   width: 100vw;
   flex-flow: column nowrap;
   align-items: center;
   justify-content: center;
+  background:
+    radial-gradient(
+      ellipse 90% 70% at 50% 38%,
+      rgba(61, 27, 109, 0.22),
+      transparent 68%
+    ),
+    radial-gradient(
+      ellipse 130% 120% at 50% 50%,
+      transparent 48%,
+      rgba(0, 0, 0, 0.62) 100%
+    ),
+    ${colors.noir};
 
+  /* Nebula: whisper-opacity glows drifting over the dark. */
   &::before {
     content: '';
     position: absolute;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    mix-blend-mode: color-dodge;
+    inset: 0;
+    z-index: 0;
+    mix-blend-mode: screen;
     background:
       radial-gradient(
-          ellipse var(--aurora-rx) var(--aurora-ry) at var(--aurora-x)
-            var(--aurora-y),
-          var(--violet) 30%,
-          var(--magenta) 65%,
-          var(--indigo) 80%,
-          var(--mist) 110%
+          ellipse 55% 50% at var(--neb-x) var(--neb-y),
+          var(--nebula-magenta),
+          transparent 62%
         )
         no-repeat,
       radial-gradient(
-          closest-side at var(--pool-x) var(--pool-y),
-          var(--pool) var(--pool-stop),
-          #000 100%
+          ellipse 60% 65% at var(--pool-x) var(--pool-y),
+          var(--nebula-violet),
+          transparent 66%
         )
         no-repeat,
       radial-gradient(
-          ellipse var(--aurora-rx) var(--aurora-ry) at var(--aurora-x)
-            var(--aurora-y),
-          var(--violet) 30%,
-          var(--magenta) 65%,
-          var(--indigo) 80%,
-          var(--mist) 110%
-        )
-        no-repeat,
-      radial-gradient(
-          closest-side at var(--pool-x) var(--pool-y),
-          var(--pool) var(--pool-stop),
-          #000 100%
+          ellipse 80% 55% at 84% 20%,
+          rgba(121, 172, 187, 0.5),
+          transparent 60%
         )
         no-repeat;
-    animation: ${drift} 48s ease-in-out infinite alternate;
+    opacity: 0.16;
+    animation: ${drift} 78s ease-in-out infinite alternate;
+  }
+
+  &[data-playing='true']::before {
+    animation:
+      ${drift} 78s ease-in-out infinite alternate,
+      ${breathe} 11s ease-in-out infinite alternate;
+  }
+
+  /* Grain: an extremely subtle film over the ground, beneath the signage. */
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    pointer-events: none;
+    background-image: url("data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20width='160'%20height='160'%3E%3Cfilter%20id='n'%3E%3CfeTurbulence%20type='fractalNoise'%20baseFrequency='0.9'%20numOctaves='2'%20stitchTiles='stitch'/%3E%3C/filter%3E%3Crect%20width='100%25'%20height='100%25'%20filter='url(%23n)'/%3E%3C/svg%3E");
+    background-size: 160px 160px;
+    mix-blend-mode: overlay;
+    opacity: 0.05;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    &::before {
+    &::before,
+    &[data-playing='true']::before {
       animation: none;
     }
   }

--- a/apps/web/src/components/play.tsx
+++ b/apps/web/src/components/play.tsx
@@ -1,9 +1,10 @@
 'use client'
 
+import { css, keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as React from 'react'
 
-import { animations, colors, layers, media } from '@/styles'
+import { colors, layers, media } from '@/styles'
 
 export interface PlayProps {
   playing: boolean
@@ -12,6 +13,7 @@ export interface PlayProps {
 
 export const Play: React.FC<PlayProps> = ({ playing, onToggle }) => (
   <Root
+    playing={playing}
     aria-pressed={playing}
     aria-label={playing ? 'Pause the ambient drone' : 'Play the ambient drone'}
     onClick={onToggle}
@@ -20,44 +22,85 @@ export const Play: React.FC<PlayProps> = ({ playing, onToggle }) => (
   </Root>
 )
 
-const Root = styled.button`
-  ${animations.booming};
+// A slow neon breath while the drone is playing.
+const pulse = keyframes`
+  from {
+    box-shadow:
+      0 0 0.4rem rgba(228, 56, 220, 0.55),
+      inset 0 0 0.4rem rgba(228, 56, 220, 0.3);
+  }
+
+  to {
+    box-shadow:
+      0 0 1rem rgba(228, 56, 220, 0.95),
+      0 0 2.4rem rgba(228, 56, 220, 0.5),
+      inset 0 0 0.8rem rgba(228, 56, 220, 0.55);
+  }
+`
+
+const Root = styled.button<{ playing: boolean }>`
   ${layers.foreground};
   position: fixed;
   right: 2rem;
   bottom: 2rem;
   display: flex;
   box-sizing: border-box;
-  width: 3.2rem;
-  height: 3.2rem;
+  width: 4rem;
+  height: 4rem;
   align-items: center;
   justify-content: center;
   padding: 0;
-  border: 2px solid ${colors.text};
-  border-radius: 0;
-  background: transparent;
-  box-shadow: 4px 4px 0 ${colors.text};
-  color: ${colors.text};
+  border: 1.5px solid ${colors.magenta};
+  border-radius: 50%;
+  background: rgba(228, 56, 220, 0.06);
+  box-shadow:
+    0 0 0.5rem rgba(228, 56, 220, 0.5),
+    inset 0 0 0.4rem rgba(228, 56, 220, 0.3);
+  color: ${colors.neonCore};
   font-size: 1.4rem;
   line-height: 1;
+  text-shadow: 0 0 0.6rem ${colors.magenta};
   cursor: pointer;
+  opacity: ${({ playing }) => (playing ? 1 : 0.6)};
+  transition:
+    opacity 250ms ease-out,
+    box-shadow 250ms ease-out,
+    transform 120ms ease-out;
+
+  ${({ playing }) =>
+    playing &&
+    css`
+      animation: ${pulse} 2.6s ease-in-out infinite alternate;
+    `}
+
+  &:hover {
+    opacity: 1;
+    box-shadow:
+      0 0 0.9rem ${colors.magenta},
+      0 0 2rem rgba(228, 56, 220, 0.7),
+      inset 0 0 0.6rem rgba(228, 56, 220, 0.5);
+  }
 
   &:active {
-    transform: translate(4px, 4px);
-    box-shadow: 0 0 0 ${colors.text};
+    transform: scale(0.94);
   }
 
   &:focus-visible {
-    outline: 2px solid ${colors.text};
+    outline: 2px solid ${colors.magenta};
     outline-offset: 4px;
   }
 
   ${media.medium} {
-    width: 3.6rem;
-    height: 3.6rem;
+    width: 4.4rem;
+    height: 4.4rem;
   }
 
   @media (prefers-reduced-motion: reduce) {
     animation: none;
+    transition: none;
+
+    &:active {
+      transform: none;
+    }
   }
 `

--- a/apps/web/src/styles/colors.ts
+++ b/apps/web/src/styles/colors.ts
@@ -3,3 +3,15 @@ export const text = 'rgb(33, 33, 33)'
 export const white = 'rgb(250, 250, 250)'
 export const blue = '#3a6186'
 export const red = '#89253e'
+
+// Neon Noir — the heritage palette kept as light sources in darkness.
+export const noir = '#06030a' // deep violet-black ground
+export const violet = '#3d1b6d'
+export const magenta = '#e438dc'
+export const indigo = '#404b8c'
+export const mist = '#79acbb'
+export const pool = '#7f4dad'
+
+// Lit foreground tones.
+export const neonCore = '#ffd9f9' // near-white magenta core so letterforms stay crisp
+export const dim = 'rgba(178, 160, 205, 0.42)' // resting signage, desaturated toward the violet ground

--- a/apps/web/src/styles/global.ts
+++ b/apps/web/src/styles/global.ts
@@ -10,6 +10,7 @@ const global: SerializedStyles = css`
 
   html {
     font-size: 62.5%;
+    color-scheme: dark;
 
     --font-default: Georgia, Cambria, 'Times New Roman', Times, serif;
     --color-text: ${colors.text};
@@ -22,6 +23,7 @@ const global: SerializedStyles = css`
     height: 100%;
     margin: 0;
     padding: 0;
+    background: ${colors.noir};
     color: var(--color-text);
     font-family: var(--font-default);
   }


### PR DESCRIPTION
## Neon Noir — the site at midnight

This reimagines the homepage as after-dark signage: the same room, the lights
turned down, the heritage palette kept as **light sources in darkness** rather
than a bright wall of magenta. Layout, type, color and motion only — no content
or copy changes, all five links kept exactly (labels, hrefs, order, structure),
and the `<h1>Langri-Sha</h1>` and metadata title untouched.

### The direction

**Ground — a room, not a void.** A deep violet-black floor (`#06030a`) with a
soft vignette and a whisper-opacity nebula (magenta / violet / mist) that drifts
very slowly. It reuses the existing `@property` drift machinery from the aurora,
dialed way down to 78s, plus an extremely subtle SVG-noise grain layered over
the ground but beneath the signage so the glow stays crisp. The body and mobile
`theme-color` are darkened to match and the document opts into a dark
`color-scheme`.

**Title — a neon sign.** The Cinzel masthead glows magenta from a near-white
core (so the letterforms stay sharp) inside a tight layered bloom with a cooler
mist rim. On load it powers on with a couple of stutters, then holds steady.

**Links — dark-bar signage.** Icons rest dimmed and desaturated toward the
violet ground, then bloom to bright magenta neon with a slight scale-up on hover
(~250ms ease-out). The nav floats further below the title, letting darkness
separate them.

**Play — a neon control.** The brutalist toggle becomes a magenta-outlined disc
with a lit glyph; while the drone plays it breathes with a slow neon pulse (and
the nebula swells a touch), and the button's rest/hover states dim and brighten.

### Choices worth calling out

- **`prefers-reduced-motion` throughout** — the power-on flicker is skipped
  entirely (the sign renders lit from the first frame), and the nebula drift,
  breathe, play pulse and hover transforms all stop. Verified in the emulator.
- **Kept the palette, changed its role** — magenta/violet/mist/indigo now read
  as emitted light on black instead of flat fills; added to the shared `colors`
  module as `noir`, a near-white `neonCore`, and a `dim` resting tone.
- **Neon rendered with `text-shadow` / `drop-shadow`** at tight radii — refined,
  not Vegas.
- **`:focus-visible`** gets a visible neon outline on both the links and the
  Play button.

### Verification

Checked in agent-browser at 1280×800 and 390×844: masthead glow/contrast/
hierarchy, link hover bloom, keyboard focus outline, the playing state, and the
reduced-motion path. `pnpm build` (which typechecks) passes from the repo root.

Draft for human review — not for merge.