### PR TITLE
Homepage redesign: Broadsheet (editorial brutalism)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 }
 
 export const viewport: Viewport = {
-  themeColor: '#333',
+  themeColor: '#f6f1e7',
 }
 
 export default function RootLayout({

--- a/apps/web/src/app/lib/header/index.tsx
+++ b/apps/web/src/app/lib/header/index.tsx
@@ -7,7 +7,12 @@ import { Docker, Github, Keybase, Npm, Stackoverflow } from './icons'
 
 export const Header: React.FC = () => (
   <Root>
+    <TopRule />
     <Title>Langri-Sha</Title>
+    <Rules>
+      <Thick />
+      <Thin />
+    </Rules>
     <Nav>
       {(
         [
@@ -52,48 +57,139 @@ export const Header: React.FC = () => (
 )
 
 const Root = styled.header`
-  ${animations.booming};
   ${layers.foreground};
   position: relative;
+  width: 100%;
+`
+
+// A vermilion color bar across the top of the sheet — the one accent.
+const TopRule = styled.div`
+  width: 100%;
+  height: 0.2rem;
+  background: ${colors.accent};
+  transform-origin: left center;
+  animation: ${animations.drawIn} 0.55s ease-out both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 `
 
 const Title = styled.h1`
   ${fonts.heading};
+  margin: 0;
   color: ${colors.text};
-  font-size: 6rem;
+  font-size: 4.2rem;
+  line-height: 0.98;
   letter-spacing: -0.03em;
-  margin-top: 0;
+  white-space: nowrap;
   user-select: none;
+  padding: 2.6rem 0 2rem;
+  animation: ${animations.revealUp} 0.6s ease-out 0.1s both;
 
   ${media.medium} {
-    font-size: 8rem;
+    font-size: 9rem;
+    padding: 4rem 0 3rem;
   }
 
   ${media.large} {
-    font-size: 10rem;
+    font-size: 15rem;
+    letter-spacing: -0.04em;
+    padding: 5rem 0 3.6rem;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`
+
+// Thick-thin double rule under the masthead — classic front-page divider.
+const Rules = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  gap: 0.3rem;
+`
+
+const rule = `
+  width: 100%;
+  background: ${colors.text};
+  transform-origin: left center;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`
+
+const Thick = styled.div`
+  ${rule};
+  height: 0.4rem;
+  animation: ${animations.drawIn} 0.6s ease-out 0.3s both;
+`
+
+const Thin = styled.div`
+  ${rule};
+  height: 0.1rem;
+  animation: ${animations.drawIn} 0.6s ease-out 0.38s both;
 `
 
 const Nav = styled.nav`
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
   width: 100%;
-  left: 0;
-  flex-flow: row nowrap;
-  align-items: center;
-  justify-content: center;
+  border-bottom: 0.1rem solid ${colors.text};
 `
 
 const Link = styled.a`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.8rem 0.8rem;
   color: ${colors.text};
-  font-size: 3.2rem;
+  font-size: 2.8rem;
   text-decoration: none;
-  margin: 1rem;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease;
+  animation: ${animations.revealUp} 0.5s ease-out both;
+
+  & + & {
+    border-left: 0.1rem solid ${colors.text};
+  }
+
+  &:hover,
+  &:focus-visible {
+    background: ${colors.text};
+    color: ${colors.background};
+    outline: none;
+  }
+
+  &:nth-of-type(1) {
+    animation-delay: 0.5s;
+  }
+  &:nth-of-type(2) {
+    animation-delay: 0.57s;
+  }
+  &:nth-of-type(3) {
+    animation-delay: 0.64s;
+  }
+  &:nth-of-type(4) {
+    animation-delay: 0.71s;
+  }
+  &:nth-of-type(5) {
+    animation-delay: 0.78s;
+  }
 
   ${media.medium} {
-    font-size: 4.8rem;
+    padding: 2.6rem 1rem;
+    font-size: 3.6rem;
   }
 
   ${media.large} {
-    font-size: 6.4rem;
+    padding: 3.2rem 1rem;
+    font-size: 4rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 `

--- a/apps/web/src/app/lib/landing.tsx
+++ b/apps/web/src/app/lib/landing.tsx
@@ -1,12 +1,12 @@
 /** @jsxImportSource @emotion/react */
 'use client'
 
-import { Global, css, keyframes } from '@emotion/react'
+import { Global } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as React from 'react'
 
 import { Drone, Play, Scene } from '@/components'
-import { global } from '@/styles'
+import { animations, colors, global, media } from '@/styles'
 
 import { Header } from './header'
 
@@ -15,213 +15,61 @@ export const Landing: React.FC = () => {
 
   return (
     <React.Fragment>
-      <Global styles={[global, gradientProperties]} />
-      <Root>
-        <Root>
-          <Header />
-          {process.env.EXPERIMENTAL_SCENE ? <Scene /> : null}
-          {playing ? <Drone /> : null}
+      <Global styles={global} />
+      <Sheet>
+        <Header />
+        {process.env.EXPERIMENTAL_SCENE ? <Scene /> : null}
+        {playing ? <Drone /> : null}
+        <Folio>
+          <FolioRule />
           <Play
             playing={playing}
             onToggle={() => setPlaying((current) => !current)}
           />
-        </Root>
-      </Root>
+        </Folio>
+      </Sheet>
     </React.Fragment>
   )
 }
 
-const gradientProperties = css`
-  /* Aurora */
-  @property --aurora-x {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 0%;
-  }
-
-  @property --aurora-y {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 0%;
-  }
-
-  @property --aurora-rx {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 140%;
-  }
-
-  @property --aurora-ry {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 140%;
-  }
-
-  /* Pool */
-  @property --pool-x {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 60%;
-  }
-
-  @property --pool-y {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 50%;
-  }
-
-  @property --pool-stop {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 20%;
-  }
-
-  /* Palette */
-  @property --violet {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #3d1b6d;
-  }
-
-  @property --magenta {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #e438dc;
-  }
-
-  @property --indigo {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #404b8c;
-  }
-
-  @property --mist {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #79acbb;
-  }
-
-  @property --pool {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #7f4dad;
-  }
-`
-
-const drift = keyframes`
-  0% {
-    --aurora-x: 0%;
-    --aurora-y: 0%;
-    --aurora-rx: 140%;
-    --aurora-ry: 140%;
-    --pool-x: 60%;
-    --pool-y: 50%;
-    --pool-stop: 20%;
-    --violet: #3d1b6d;
-    --magenta: #e438dc;
-    --indigo: #404b8c;
-    --mist: #79acbb;
-    --pool: #7f4dad;
-  }
-
-  33% {
-    --aurora-x: 12%;
-    --aurora-y: 8%;
-    --aurora-rx: 165%;
-    --aurora-ry: 120%;
-    --pool-x: 50%;
-    --pool-y: 42%;
-    --pool-stop: 32%;
-    --violet: #4a1a86;
-    --magenta: #ff2f92;
-    --indigo: #3d5bb0;
-    --mist: #4dd7e8;
-    --pool: #9a3df0;
-  }
-
-  66% {
-    --aurora-x: 4%;
-    --aurora-y: 18%;
-    --aurora-rx: 120%;
-    --aurora-ry: 170%;
-    --pool-x: 66%;
-    --pool-y: 58%;
-    --pool-stop: 26%;
-    --violet: #33206e;
-    --magenta: #c433ff;
-    --indigo: #4a3f9e;
-    --mist: #62b8d9;
-    --pool: #b03ddb;
-  }
-
-  100% {
-    --aurora-x: 16%;
-    --aurora-y: 4%;
-    --aurora-rx: 150%;
-    --aurora-ry: 135%;
-    --pool-x: 56%;
-    --pool-y: 48%;
-    --pool-stop: 22%;
-    --violet: #3d1b6d;
-    --magenta: #f038c8;
-    --indigo: #404b8c;
-    --mist: #79acbb;
-    --pool: #8748c4;
-  }
-`
-
-const Root = styled.div`
+const Sheet = styled.div`
+  position: relative;
   display: flex;
-  height: 100vh;
-  width: 100vw;
+  min-height: 100vh;
+  width: 100%;
   flex-flow: column nowrap;
-  align-items: center;
-  justify-content: center;
+  box-sizing: border-box;
+  padding: 2.4rem 2rem;
+  background: ${colors.background};
+  color: ${colors.text};
 
-  &::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    mix-blend-mode: color-dodge;
-    background:
-      radial-gradient(
-          ellipse var(--aurora-rx) var(--aurora-ry) at var(--aurora-x)
-            var(--aurora-y),
-          var(--violet) 30%,
-          var(--magenta) 65%,
-          var(--indigo) 80%,
-          var(--mist) 110%
-        )
-        no-repeat,
-      radial-gradient(
-          closest-side at var(--pool-x) var(--pool-y),
-          var(--pool) var(--pool-stop),
-          #000 100%
-        )
-        no-repeat,
-      radial-gradient(
-          ellipse var(--aurora-rx) var(--aurora-ry) at var(--aurora-x)
-            var(--aurora-y),
-          var(--violet) 30%,
-          var(--magenta) 65%,
-          var(--indigo) 80%,
-          var(--mist) 110%
-        )
-        no-repeat,
-      radial-gradient(
-          closest-side at var(--pool-x) var(--pool-y),
-          var(--pool) var(--pool-stop),
-          #000 100%
-        )
-        no-repeat;
-    animation: ${drift} 48s ease-in-out infinite alternate;
+  ${media.medium} {
+    padding: 4rem;
   }
+
+  ${media.large} {
+    padding: 6rem;
+  }
+`
+
+// Closing folio: a rule that runs the width of the sheet with the ambient-audio
+// control set at its right end.
+const Folio = styled.footer`
+  display: flex;
+  align-items: center;
+  gap: 1.6rem;
+  margin-top: auto;
+  padding-top: 3.2rem;
+`
+
+const FolioRule = styled.div`
+  flex: 1 1 auto;
+  height: 0.1rem;
+  background: ${colors.text};
+  transform-origin: left center;
+  animation: ${animations.drawIn} 0.6s ease-out 0.8s both;
 
   @media (prefers-reduced-motion: reduce) {
-    &::before {
-      animation: none;
-    }
+    animation: none;
   }
 `

--- a/apps/web/src/components/play.tsx
+++ b/apps/web/src/components/play.tsx
@@ -3,7 +3,7 @@
 import styled from '@emotion/styled'
 import * as React from 'react'
 
-import { animations, colors, layers, media } from '@/styles'
+import { animations, colors, media } from '@/styles'
 
 export interface PlayProps {
   playing: boolean
@@ -21,35 +21,44 @@ export const Play: React.FC<PlayProps> = ({ playing, onToggle }) => (
 )
 
 const Root = styled.button`
-  ${animations.booming};
-  ${layers.foreground};
-  position: fixed;
-  right: 2rem;
-  bottom: 2rem;
   display: flex;
   box-sizing: border-box;
   width: 3.2rem;
   height: 3.2rem;
+  flex: 0 0 auto;
   align-items: center;
   justify-content: center;
   padding: 0;
-  border: 2px solid ${colors.text};
+  border: 0.2rem solid ${colors.text};
   border-radius: 0;
-  background: transparent;
-  box-shadow: 4px 4px 0 ${colors.text};
-  color: ${colors.text};
+  background: ${(props) =>
+    props['aria-pressed'] ? colors.accent : 'transparent'};
+  box-shadow: 0.4rem 0.4rem 0 ${colors.text};
+  color: ${(props) =>
+    props['aria-pressed'] ? colors.background : colors.text};
   font-size: 1.4rem;
   line-height: 1;
   cursor: pointer;
+  transition:
+    background-color 150ms ease,
+    color 150ms ease,
+    transform 90ms ease,
+    box-shadow 90ms ease;
+  animation: ${animations.revealUp} 0.5s ease-out 0.85s both;
+
+  &:hover {
+    background: ${colors.text};
+    color: ${colors.background};
+  }
 
   &:active {
-    transform: translate(4px, 4px);
+    transform: translate(0.4rem, 0.4rem);
     box-shadow: 0 0 0 ${colors.text};
   }
 
   &:focus-visible {
-    outline: 2px solid ${colors.text};
-    outline-offset: 4px;
+    outline: 0.2rem solid ${colors.accent};
+    outline-offset: 0.4rem;
   }
 
   ${media.medium} {

--- a/apps/web/src/styles/animations.ts
+++ b/apps/web/src/styles/animations.ts
@@ -16,3 +16,34 @@ export const booming: SerializedStyles = css`
   animation-duration: 3s;
   animation-name: ${boom};
 `
+
+/**
+ * Print-shop reveal — restrained, single-shot entrances. Elements carry their
+ * final (visible) state in their own rules; these keyframes hide them at 0s and
+ * settle them in. Under reduced motion, callers drop the animation and the
+ * element is simply shown.
+ */
+
+// Masthead / link cells fade up a hair.
+export const revealUp = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(1.2rem);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`
+
+// Hairline rules draw across, like a press pulling a line.
+export const drawIn = keyframes`
+  from {
+    transform: scaleX(0);
+  }
+
+  to {
+    transform: scaleX(1);
+  }
+`

--- a/apps/web/src/styles/colors.ts
+++ b/apps/web/src/styles/colors.ts
@@ -1,5 +1,13 @@
-export const background = `rgb(255, 250, 255)`
-export const text = 'rgb(33, 33, 33)'
+// Broadsheet palette — ink on warm paper, one editorial accent.
+export const paper = '#f6f1e7'
+export const ink = '#1a1714'
+export const accent = '#c1272d'
+
+// Semantic aliases (consumed across the app).
+export const background = paper
+export const text = ink
+
+// Retained for reference / incidental use.
 export const white = 'rgb(250, 250, 250)'
 export const blue = '#3a6186'
 export const red = '#89253e'

--- a/apps/web/src/styles/global.ts
+++ b/apps/web/src/styles/global.ts
@@ -10,8 +10,11 @@ const global: SerializedStyles = css`
 
   html {
     font-size: 62.5%;
+    overflow-x: hidden;
 
-    --font-default: Georgia, Cambria, 'Times New Roman', Times, serif;
+    --font-default:
+      'Iowan Old Style', 'Palatino Linotype', Palatino, Georgia,
+      'Times New Roman', Times, serif;
     --color-text: ${colors.text};
   }
 
@@ -22,8 +25,11 @@ const global: SerializedStyles = css`
     height: 100%;
     margin: 0;
     padding: 0;
+    background: ${colors.background};
     color: var(--color-text);
     font-family: var(--font-default);
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
   }
 
   #app {


### PR DESCRIPTION
## Broadsheet — editorial brutalism

A full pivot away from the neon aurora gradient toward a newspaper front page, set in ink on paper. The whole viewport becomes a typeset "sheet": warm paper ground, near-black ink, and one sparing editorial accent.

### Direction & choices

- **Palette (ink on paper).** Repaletted the tokens to `#f6f1e7` warm paper, `#1a1714` ink, and a single vermilion accent (`#c1272d`). The semantic `background`/`text` aliases now point at paper/ink so every existing consumer inherits the new ground, and the paper is painted on the body with legibility-focused font smoothing. The accent is used deliberately and only twice: the color bar that opens the sheet, and the Play button when the drone is active.
- **Masthead composition.** The `<h1>` is set enormous and flush-left in the Cinzel Decorative subset with tight negative tracking — it dominates the top of the page and crops toward the sheet edge at large sizes (`overflow-x` is clipped so this reads as intent, not a scrollbar). A vermilion hairline opens the sheet; a classic thick-thin double rule closes the masthead.
- **Ruled index.** The five links become a front-page index: one row of equal cells divided by 1px ink hairlines, generous cell padding, with each cell inverting to ink-on-paper on hover and focus over a crisp 150ms transition. Links, order, `title`/labels, `href`s and icon contents are all unchanged.
- **Folio.** A closing hairline runs the foot of the sheet with the ambient-audio control set at its right end — giving the (already brutalist) Play button a deliberate home instead of floating fixed. It's recolored ink-on-paper, inverts on hover, and fills vermilion while playing.
- **Motion — a restrained print-shop reveal.** Rules draw in (`scaleX`, like a press pulling a line) and the masthead and index cells stagger up with small `translateY` fades. Nothing loops and there's no ambient animation. Every reveal is disabled under `@media (prefers-reduced-motion: reduce)`, with elements resolving to their visible state.

### Constraints honored

- `<h1>` text and the metadata `title` remain exactly `Langri-Sha`.
- Same five links, order, labels/`title` attributes, `href`s, and icon components inside a `<nav>` of anchors.
- Play button and its drone-toggle behavior preserved; only restyled/repositioned.
- Emotion styled-components, `@/styles` modules, rem sizing on the 62.5% base, and the em-based `media` helpers throughout. No new font dependencies (the existing Cinzel subset renders the masthead; supporting stack is a strong system serif). No `packages/*` or projen changes.

### Verification

- Screenshotted at desktop (1280×800) and narrow (390×844); checked cell hover inversion, keyboard focus, and the Play playing/paused states.
- `pnpm build` from the repo root passes (typechecks clean).

Commits are atomic: tokens → motion primitives → composition → Play button.
