### PR TITLE
Homepage redesign: Aether

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 }
 
 export const viewport: Viewport = {
-  themeColor: '#333',
+  themeColor: '#fafbfd',
 }
 
 export default function RootLayout({

--- a/apps/web/src/app/lib/header/index.tsx
+++ b/apps/web/src/app/lib/header/index.tsx
@@ -1,3 +1,4 @@
+import { keyframes } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as React from 'react'
 
@@ -51,49 +52,129 @@ export const Header: React.FC = () => (
   </Root>
 )
 
+const bob = keyframes`
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(-6px);
+  }
+`
+
 const Root = styled.header`
-  ${animations.booming};
   ${layers.foreground};
   position: relative;
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+  text-align: center;
 `
 
 const Title = styled.h1`
   ${fonts.heading};
+  ${animations.rising};
   color: ${colors.text};
-  font-size: 6rem;
-  letter-spacing: -0.03em;
-  margin-top: 0;
+  margin: 0 0 3.6rem;
+  font-size: 4.4rem;
+  font-weight: 400;
+  line-height: 1.05;
+  letter-spacing: 0.08em;
+  text-indent: 0.08em;
   user-select: none;
 
   ${media.medium} {
-    font-size: 8rem;
+    margin-bottom: 4.8rem;
+    font-size: 6.4rem;
   }
 
   ${media.large} {
-    font-size: 10rem;
+    font-size: 8rem;
   }
 `
 
 const Nav = styled.nav`
+  ${animations.rising};
+  animation-delay: 180ms;
   display: flex;
-  width: 100%;
-  left: 0;
   flex-flow: row nowrap;
   align-items: center;
   justify-content: center;
+  gap: 1.4rem;
+
+  ${media.medium} {
+    gap: 2rem;
+  }
 `
 
 const Link = styled.a`
+  position: relative;
+  top: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 5.2rem;
+  height: 5.2rem;
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(12px) saturate(150%);
+  -webkit-backdrop-filter: blur(12px) saturate(150%);
+  box-shadow:
+    0 1px 2px rgba(40, 50, 74, 0.06),
+    0 10px 28px rgba(40, 50, 74, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.85);
   color: ${colors.text};
-  font-size: 3.2rem;
+  font-size: 2.4rem;
   text-decoration: none;
-  margin: 1rem;
+  transition:
+    top 250ms ease,
+    box-shadow 250ms ease,
+    background-color 250ms ease,
+    border-color 250ms ease;
+  animation: ${bob} 8s ease-in-out infinite alternate;
 
-  ${media.medium} {
-    font-size: 4.8rem;
+  &:nth-of-type(2) {
+    animation-delay: -1.6s;
+  }
+  &:nth-of-type(3) {
+    animation-delay: -3.2s;
+  }
+  &:nth-of-type(4) {
+    animation-delay: -4.8s;
+  }
+  &:nth-of-type(5) {
+    animation-delay: -6.4s;
   }
 
-  ${media.large} {
-    font-size: 6.4rem;
+  &:hover {
+    top: -2px;
+    border-color: rgba(255, 255, 255, 0.9);
+    background-color: rgba(255, 255, 255, 0.72);
+    box-shadow:
+      0 2px 6px rgba(40, 50, 74, 0.08),
+      0 18px 42px rgba(40, 50, 74, 0.16),
+      inset 0 1px 0 rgba(255, 255, 255, 0.95);
+  }
+
+  &:focus-visible {
+    top: -2px;
+    outline: none;
+    border-color: rgba(255, 255, 255, 0.9);
+    background-color: rgba(255, 255, 255, 0.72);
+    box-shadow:
+      0 18px 42px rgba(40, 50, 74, 0.14),
+      0 0 0 3px rgba(40, 50, 74, 0.28),
+      inset 0 1px 0 rgba(255, 255, 255, 0.95);
+  }
+
+  ${media.medium} {
+    width: 6.4rem;
+    height: 6.4rem;
+    font-size: 2.8rem;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    transition: none;
   }
 `

--- a/apps/web/src/app/lib/landing.tsx
+++ b/apps/web/src/app/lib/landing.tsx
@@ -6,7 +6,7 @@ import styled from '@emotion/styled'
 import * as React from 'react'
 
 import { Drone, Play, Scene } from '@/components'
-import { global } from '@/styles'
+import { colors, global, layers } from '@/styles'
 
 import { Header } from './header'
 
@@ -15,213 +15,161 @@ export const Landing: React.FC = () => {
 
   return (
     <React.Fragment>
-      <Global styles={[global, gradientProperties]} />
+      <Global styles={global} />
       <Root>
-        <Root>
-          <Header />
-          {process.env.EXPERIMENTAL_SCENE ? <Scene /> : null}
-          {playing ? <Drone /> : null}
-          <Play
-            playing={playing}
-            onToggle={() => setPlaying((current) => !current)}
-          />
-        </Root>
+        <Aether aria-hidden="true">
+          <Blob css={lilacBlob} />
+          <Blob css={blushBlob} />
+          <Blob css={skyBlob} />
+          <Blob css={periwinkleBlob} />
+        </Aether>
+        <Header />
+        {process.env.EXPERIMENTAL_SCENE ? <Scene /> : null}
+        {playing ? <Drone /> : null}
+        <Play
+          playing={playing}
+          onToggle={() => setPlaying((current) => !current)}
+        />
       </Root>
     </React.Fragment>
   )
 }
 
-const gradientProperties = css`
-  /* Aurora */
-  @property --aurora-x {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 0%;
+const driftOne = keyframes`
+  from {
+    transform: translate3d(0, 0, 0) scale(1);
   }
-
-  @property --aurora-y {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 0%;
-  }
-
-  @property --aurora-rx {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 140%;
-  }
-
-  @property --aurora-ry {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 140%;
-  }
-
-  /* Pool */
-  @property --pool-x {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 60%;
-  }
-
-  @property --pool-y {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 50%;
-  }
-
-  @property --pool-stop {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 20%;
-  }
-
-  /* Palette */
-  @property --violet {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #3d1b6d;
-  }
-
-  @property --magenta {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #e438dc;
-  }
-
-  @property --indigo {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #404b8c;
-  }
-
-  @property --mist {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #79acbb;
-  }
-
-  @property --pool {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #7f4dad;
+  to {
+    transform: translate3d(5vmax, 4vmax, 0) scale(1.14);
   }
 `
 
-const drift = keyframes`
-  0% {
-    --aurora-x: 0%;
-    --aurora-y: 0%;
-    --aurora-rx: 140%;
-    --aurora-ry: 140%;
-    --pool-x: 60%;
-    --pool-y: 50%;
-    --pool-stop: 20%;
-    --violet: #3d1b6d;
-    --magenta: #e438dc;
-    --indigo: #404b8c;
-    --mist: #79acbb;
-    --pool: #7f4dad;
+const driftTwo = keyframes`
+  from {
+    transform: translate3d(0, 0, 0) scale(1.08);
   }
-
-  33% {
-    --aurora-x: 12%;
-    --aurora-y: 8%;
-    --aurora-rx: 165%;
-    --aurora-ry: 120%;
-    --pool-x: 50%;
-    --pool-y: 42%;
-    --pool-stop: 32%;
-    --violet: #4a1a86;
-    --magenta: #ff2f92;
-    --indigo: #3d5bb0;
-    --mist: #4dd7e8;
-    --pool: #9a3df0;
+  to {
+    transform: translate3d(-6vmax, 3vmax, 0) scale(0.96);
   }
+`
 
-  66% {
-    --aurora-x: 4%;
-    --aurora-y: 18%;
-    --aurora-rx: 120%;
-    --aurora-ry: 170%;
-    --pool-x: 66%;
-    --pool-y: 58%;
-    --pool-stop: 26%;
-    --violet: #33206e;
-    --magenta: #c433ff;
-    --indigo: #4a3f9e;
-    --mist: #62b8d9;
-    --pool: #b03ddb;
+const driftThree = keyframes`
+  from {
+    transform: translate3d(0, 0, 0) scale(1);
   }
+  to {
+    transform: translate3d(4vmax, -5vmax, 0) scale(1.12);
+  }
+`
 
-  100% {
-    --aurora-x: 16%;
-    --aurora-y: 4%;
-    --aurora-rx: 150%;
-    --aurora-ry: 135%;
-    --pool-x: 56%;
-    --pool-y: 48%;
-    --pool-stop: 22%;
-    --violet: #3d1b6d;
-    --magenta: #f038c8;
-    --indigo: #404b8c;
-    --mist: #79acbb;
-    --pool: #8748c4;
+const driftFour = keyframes`
+  from {
+    transform: translate3d(0, 0, 0) scale(1.05);
+  }
+  to {
+    transform: translate3d(-4vmax, -4vmax, 0) scale(1);
+  }
+`
+
+const lilacBlob = css`
+  top: -22vmax;
+  left: -16vmax;
+  width: 64vmax;
+  height: 64vmax;
+  background: radial-gradient(
+    circle at center,
+    ${colors.lilac} 0%,
+    transparent 68%
+  );
+  opacity: 0.6;
+  animation: ${driftOne} 78s ease-in-out infinite alternate;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`
+
+const blushBlob = css`
+  top: -12vmax;
+  right: -20vmax;
+  width: 56vmax;
+  height: 56vmax;
+  background: radial-gradient(
+    circle at center,
+    ${colors.blush} 0%,
+    transparent 68%
+  );
+  opacity: 0.55;
+  animation: ${driftTwo} 88s ease-in-out infinite alternate;
+  animation-delay: -12s;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`
+
+const skyBlob = css`
+  bottom: -26vmax;
+  left: 2vmax;
+  width: 60vmax;
+  height: 60vmax;
+  background: radial-gradient(
+    circle at center,
+    ${colors.sky} 0%,
+    transparent 68%
+  );
+  opacity: 0.6;
+  animation: ${driftThree} 82s ease-in-out infinite alternate;
+  animation-delay: -30s;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`
+
+const periwinkleBlob = css`
+  bottom: -20vmax;
+  right: -12vmax;
+  width: 58vmax;
+  height: 58vmax;
+  background: radial-gradient(
+    circle at center,
+    ${colors.periwinkle} 0%,
+    transparent 68%
+  );
+  opacity: 0.5;
+  animation: ${driftFour} 74s ease-in-out infinite alternate;
+  animation-delay: -48s;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
   }
 `
 
 const Root = styled.div`
+  position: relative;
   display: flex;
   height: 100vh;
   width: 100vw;
   flex-flow: column nowrap;
   align-items: center;
   justify-content: center;
+  overflow: hidden;
+  background-color: ${colors.background};
+`
 
-  &::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    mix-blend-mode: color-dodge;
-    background:
-      radial-gradient(
-          ellipse var(--aurora-rx) var(--aurora-ry) at var(--aurora-x)
-            var(--aurora-y),
-          var(--violet) 30%,
-          var(--magenta) 65%,
-          var(--indigo) 80%,
-          var(--mist) 110%
-        )
-        no-repeat,
-      radial-gradient(
-          closest-side at var(--pool-x) var(--pool-y),
-          var(--pool) var(--pool-stop),
-          #000 100%
-        )
-        no-repeat,
-      radial-gradient(
-          ellipse var(--aurora-rx) var(--aurora-ry) at var(--aurora-x)
-            var(--aurora-y),
-          var(--violet) 30%,
-          var(--magenta) 65%,
-          var(--indigo) 80%,
-          var(--mist) 110%
-        )
-        no-repeat,
-      radial-gradient(
-          closest-side at var(--pool-x) var(--pool-y),
-          var(--pool) var(--pool-stop),
-          #000 100%
-        )
-        no-repeat;
-    animation: ${drift} 48s ease-in-out infinite alternate;
-  }
+const Aether = styled.div`
+  ${layers.background};
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+`
 
-  @media (prefers-reduced-motion: reduce) {
-    &::before {
-      animation: none;
-    }
-  }
+const Blob = styled.div`
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  mix-blend-mode: multiply;
+  will-change: transform;
 `

--- a/apps/web/src/components/play.tsx
+++ b/apps/web/src/components/play.tsx
@@ -21,43 +21,69 @@ export const Play: React.FC<PlayProps> = ({ playing, onToggle }) => (
 )
 
 const Root = styled.button`
-  ${animations.booming};
+  ${animations.rising};
   ${layers.foreground};
   position: fixed;
-  right: 2rem;
-  bottom: 2rem;
+  right: 2.4rem;
+  bottom: 2.4rem;
   display: flex;
   box-sizing: border-box;
-  width: 3.2rem;
-  height: 3.2rem;
+  width: 4.8rem;
+  height: 4.8rem;
   align-items: center;
   justify-content: center;
   padding: 0;
-  border: 2px solid ${colors.text};
-  border-radius: 0;
-  background: transparent;
-  box-shadow: 4px 4px 0 ${colors.text};
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 50%;
+  background-color: rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(12px) saturate(150%);
+  -webkit-backdrop-filter: blur(12px) saturate(150%);
+  box-shadow:
+    0 1px 2px rgba(40, 50, 74, 0.06),
+    0 10px 28px rgba(40, 50, 74, 0.1),
+    inset 0 1px 0 rgba(255, 255, 255, 0.85);
   color: ${colors.text};
-  font-size: 1.4rem;
+  font-size: 1.6rem;
   line-height: 1;
   cursor: pointer;
+  transition:
+    transform 250ms ease,
+    box-shadow 250ms ease,
+    background-color 250ms ease,
+    border-color 250ms ease;
+
+  &:hover {
+    transform: translateY(-2px);
+    border-color: rgba(255, 255, 255, 0.9);
+    background-color: rgba(255, 255, 255, 0.72);
+    box-shadow:
+      0 2px 6px rgba(40, 50, 74, 0.08),
+      0 18px 42px rgba(40, 50, 74, 0.16),
+      inset 0 1px 0 rgba(255, 255, 255, 0.95);
+  }
 
   &:active {
-    transform: translate(4px, 4px);
-    box-shadow: 0 0 0 ${colors.text};
+    transform: translateY(0);
+    box-shadow:
+      0 1px 2px rgba(40, 50, 74, 0.08),
+      inset 0 1px 0 rgba(255, 255, 255, 0.7);
   }
 
   &:focus-visible {
-    outline: 2px solid ${colors.text};
-    outline-offset: 4px;
+    outline: none;
+    box-shadow:
+      0 10px 28px rgba(40, 50, 74, 0.12),
+      0 0 0 3px rgba(40, 50, 74, 0.28),
+      inset 0 1px 0 rgba(255, 255, 255, 0.9);
   }
 
   ${media.medium} {
-    width: 3.6rem;
-    height: 3.6rem;
+    width: 5.2rem;
+    height: 5.2rem;
+    font-size: 1.8rem;
   }
 
   @media (prefers-reduced-motion: reduce) {
-    animation: none;
+    transition: none;
   }
 `

--- a/apps/web/src/styles/animations.ts
+++ b/apps/web/src/styles/animations.ts
@@ -1,22 +1,5 @@
 import { type SerializedStyles, css, keyframes } from '@emotion/react'
 
-const boom = keyframes`
-  from {
-    opacity: 0;
-    transform: translateY(20px) scale(0.8);
-  }
-
-  to {
-    opacity: 1;
-    transform: translateY(0) scale(1);
-  }
-`
-
-export const booming: SerializedStyles = css`
-  animation-duration: 3s;
-  animation-name: ${boom};
-`
-
 const rise = keyframes`
   from {
     opacity: 0;

--- a/apps/web/src/styles/animations.ts
+++ b/apps/web/src/styles/animations.ts
@@ -16,3 +16,23 @@ export const booming: SerializedStyles = css`
   animation-duration: 3s;
   animation-name: ${boom};
 `
+
+const rise = keyframes`
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+`
+
+export const rising: SerializedStyles = css`
+  animation: ${rise} 1200ms cubic-bezier(0.22, 1, 0.36, 1) backwards;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+`

--- a/apps/web/src/styles/colors.ts
+++ b/apps/web/src/styles/colors.ts
@@ -1,5 +1,9 @@
-export const background = `rgb(255, 250, 255)`
-export const text = 'rgb(33, 33, 33)'
-export const white = 'rgb(250, 250, 250)'
-export const blue = '#3a6186'
-export const red = '#89253e'
+export const background = 'rgb(250, 251, 253)'
+export const text = 'rgb(40, 50, 74)'
+export const white = 'rgb(255, 255, 255)'
+
+// Aether — the heritage palette desaturated into soft, airy pastels.
+export const lilac = '#c7b9ef'
+export const blush = '#f4c6df'
+export const sky = '#bcd8f1'
+export const periwinkle = '#cdd3f3'


### PR DESCRIPTION
## Aether — soft light and air

The inverse of the saturated neon aurora: bright, weightless, calm. Morning light instead of midnight. This is one of three parallel explorations of the homepage; it reimagines only layout, typography, colour, spacing and motion — no content, links or copy change.

### The ground
- The aurora radial-gradient wall (with its `@property` custom props, `drift` keyframes and `color-dodge` blend) is replaced by a palest cool-white field (`rgb(250, 251, 253)`).
- Over it drift **four very large, heavily blurred pastel blobs** — the heritage palette (violet / magenta / indigo / mist) desaturated into **lilac, blush, sky and periwinkle**. They're oversized radial gradients at low opacity with `filter: blur(90px)` and `mix-blend-mode: multiply`, so they read as light on frosted glass rather than colour blocks.
- Each blob drifts on its own slow 74–88s `alternate` loop (with negative delays so they start out of phase), gently translating and scaling — the page feels like it's breathing.

### Typography
- The `<h1>` steps **down** from monumental (was 6/8/10rem) to a restrained, elegant scale (4.4/6.4/8rem) with generous positive letter-spacing, in the new deep charcoal-blue ink so it floats rather than shouts. It stays exactly `Langri-Sha` in the Cinzel Decorative subset, still an `<h1>`.
- Whitespace carries the composition — title and nav are centred with room to breathe.

### Links & Play — floating frosted chips
- The five icon links (unchanged: same order, labels, `title`s, `href`s and SVG icons) become soft circular **frosted-glass chips**: translucent white with `backdrop-filter: blur`, a hairline light border and layered soft shadows.
- Hover/focus gives a gentle 2px lift with deepening shadow (~250ms ease); a barely-perceptible, staggered idle bob (8s, a few px) keeps them alive.
- The Play button (same drone-toggle behaviour) is restyled as a matching frosted chip resting quietly in its corner.

### Motion
- A shared, gentle `rising` entrance fades content up with a slight stagger between title and nav; the old `boom` entrance is retired.
- **Every animation respects `prefers-reduced-motion: reduce`** — blob drift, idle bob and entrances all switch off.

### Conventions & checks
- Emotion styled-components, the `@/styles` modules, rem sizing on the 62.5% base and the em-based `media` helpers throughout. Only `apps/web` (hand-maintained) was touched; no projen `packages/*`.
- Verified visually at desktop (1280×800), mobile (390×844) and a 320px extreme (chips never clip); hover/focus states checked.
- `pnpm build` (typecheck) passes.

Commits are atomic: ground/blobs → header type & chips → Play button.