### PR TITLE
Add a rashadnyk workspace to the organization

### DIFF
--- a/terraform/org/main.tf
+++ b/terraform/org/main.tf
@@ -87,6 +87,33 @@ module "public_dns" {
   ]
 }
 
+module "rashadnyk" {
+  source = "github.com/langri-sha/terraform-google-cloud-platform//modules/workspace?ref=v0.11.0"
+
+  name = "rashadnyk"
+
+  admin_members   = module.org.admin_members
+  billing_account = module.org.billing_account
+  org_id          = module.org.org_id
+  org_project_id  = module.org.project_id
+
+  service_account_roles = [
+    "roles/billing.projectManager",
+    "roles/editor",
+    "roles/iam.serviceAccountAdmin",
+    "roles/resourcemanager.folderAdmin",
+    "roles/resourcemanager.projectCreator",
+    "roles/resourcemanager.projectDeleter",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/secretmanager.admin",
+  ]
+
+  depends_on = [
+    module.org,
+    module.terraform_admin,
+  ]
+}
+
 module "web" {
   source = "github.com/langri-sha/terraform-google-cloud-platform//modules/workspace?ref=v0.11.0"
 

--- a/terraform/org/outputs.tf
+++ b/terraform/org/outputs.tf
@@ -48,6 +48,16 @@ output "org_project_id" {
   value       = module.org.project_id
 }
 
+output "rashadnyk_folder" {
+  description = "Folder where workspace resources are created."
+  value       = module.rashadnyk.folder
+}
+
+output "rashadnyk_service_account_email" {
+  description = "Email of the Terrraform service account managing the workspace."
+  value       = module.rashadnyk.service_account_email
+}
+
 output "web_folder" {
   description = "Folder where workspace resources are created."
   value       = module.web.folder


### PR DESCRIPTION
Adds a `rashadnyk` workspace to `terraform/org` — the folder and Terraform service account that will manage the rashadnyk application's infrastructure, ahead of moving that management into this organization.