### PR TITLE
Reconcile @langri-sha/babel-preset with the published 0.5.6

### DIFF
--- a/change/@langri-sha-babel-preset-042ca538-1f22-44b6-bf50-fcbc0d4ae577.json
+++ b/change/@langri-sha-babel-preset-042ca538-1f22-44b6-bf50-fcbc0d4ae577.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix(deps): update emotion monorepo",
-  "packageName": "@langri-sha/babel-preset",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-babel-preset-4ae3956e-0a57-4ac3-8d8f-46eeb9da7c79.json
+++ b/change/@langri-sha-babel-preset-4ae3956e-0a57-4ac3-8d8f-46eeb9da7c79.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Update @types/node to 24.13.2",
-  "packageName": "@langri-sha/babel-preset",
-  "email": "filip.dupanovic@gmail.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-babel-preset-601a395a-e794-4278-a7ce-1cd8a45e1c3b.json
+++ b/change/@langri-sha-babel-preset-601a395a-e794-4278-a7ce-1cd8a45e1c3b.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore(deps): update dependency @types/node to v20.19.41",
-  "packageName": "@langri-sha/babel-preset",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-babel-preset-91242261-59e2-4d36-a3ee-62579fc62b40.json
+++ b/change/@langri-sha-babel-preset-91242261-59e2-4d36-a3ee-62579fc62b40.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix(deps): update babel monorepo to v7.29.7",
-  "packageName": "@langri-sha/babel-preset",
-  "email": "email not defined",
-  "dependentChangeType": "patch"
-}

--- a/change/@langri-sha-babel-preset-e2265fa8-38b0-496d-a0ec-0eb06b78a3b7.json
+++ b/change/@langri-sha-babel-preset-e2265fa8-38b0-496d-a0ec-0eb06b78a3b7.json
@@ -1,6 +1,6 @@
 {
   "type": "none",
-  "comment": "chore: consume @langri-sha/tsconfig and @langri-sha/vitest from npm instead of the workspace",
+  "comment": "chore: reconcile the package version with the published 0.5.6",
   "packageName": "@langri-sha/babel-preset",
   "email": "filip.dupanovic@gmail.com",
   "dependentChangeType": "none"

--- a/packages/babel-preset/CHANGELOG.json
+++ b/packages/babel-preset/CHANGELOG.json
@@ -2,6 +2,47 @@
   "name": "@langri-sha/babel-preset",
   "entries": [
     {
+      "date": "Sat, 25 Jul 2026 22:50:38 GMT",
+      "version": "0.5.6",
+      "tag": "@langri-sha/babel-preset_v0.5.6",
+      "comments": {
+        "patch": [
+          {
+            "author": "email not defined",
+            "package": "@langri-sha/babel-preset",
+            "commit": "faee4550956a2f6f151d458180cf029b460c0dcc",
+            "comment": "fix(deps): update emotion monorepo"
+          },
+          {
+            "author": "filip.dupanovic@gmail.com",
+            "package": "@langri-sha/babel-preset",
+            "commit": "ebb266397902e83a913e56dbd7291fcd6968055a",
+            "comment": "Update @types/node to 24.13.2"
+          },
+          {
+            "author": "email not defined",
+            "package": "@langri-sha/babel-preset",
+            "commit": "12217804e625f27f797a0c5d3976f77f754a85bd",
+            "comment": "chore(deps): update dependency @types/node to v20.19.41"
+          },
+          {
+            "author": "email not defined",
+            "package": "@langri-sha/babel-preset",
+            "commit": "bd1fb6eb1aeaa993b6964ad273b8ae215c561161",
+            "comment": "fix(deps): update babel monorepo to v7.29.7"
+          }
+        ],
+        "none": [
+          {
+            "author": "filip.dupanovic@gmail.com",
+            "package": "@langri-sha/babel-preset",
+            "commit": "ab3e419d3966634386c1fa27af182b453a895505",
+            "comment": "chore: consume @langri-sha/tsconfig and @langri-sha/vitest from npm instead of the workspace"
+          }
+        ]
+      }
+    },
+    {
       "date": "Sun, 17 May 2026 20:22:40 GMT",
       "version": "0.5.5",
       "tag": "@langri-sha/babel-preset_v0.5.5",

--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Change Log - @langri-sha/babel-preset
 
-This log was last generated on Sun, 17 May 2026 20:22:40 GMT and should not be manually modified.
+<!-- This log was last generated on Sat, 25 Jul 2026 22:50:38 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 0.5.6
+
+Sat, 25 Jul 2026 22:50:38 GMT
+
+### Patches
+
+- fix(deps): update emotion monorepo (email not defined)
+- Update @types/node to 24.13.2 (filip.dupanovic@gmail.com)
+- chore(deps): update dependency @types/node to v20.19.41 (email not defined)
+- fix(deps): update babel monorepo to v7.29.7 (email not defined)
 
 ## 0.5.5
 

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langri-sha/babel-preset",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "bugs": {
     "url": "https://github.com/langri-sha/langri-sha.com/issues"
   },


### PR DESCRIPTION
Unblocks the Release workflow, which has been failing on a version collision.

## What happened

The 2026-07-25 Release run
([30164017013](https://github.com/langri-sha/langri-sha.com/actions/runs/30164017013),
started 15:38:21Z) published `@langri-sha/babel-preset@0.5.6` to npm at
15:38:54Z, then died on `@langri-sha/babel-test`'s `prepublishOnly` build —
before beachball could commit the version bumps back to git.

So npm advanced to `0.5.6` while git stayed at `0.5.5` with all five change
files still pending. Every release since recomputed `0.5.6` and hit:

```
ERROR: Attempting to publish package versions that already exist in the registry:
  • @langri-sha/babel-preset@0.5.6
```

Most recently in
[30178224776](https://github.com/langri-sha/langri-sha.com/actions/runs/30178224776).

## Changes

Applies what the aborted run would have committed — `beachball bump` scoped to
`packages/babel-preset`:

- **`packages/babel-preset/package.json`** — `0.5.5` → `0.5.6`
- **`packages/babel-preset/CHANGELOG.{md,json}`** — the four patch entries
- **Consume the five pending `change/*.json`** for the package
- **Add a `type: none` change file** — the bump itself has no change file
  (beachball normally pushes bump commits straight to `main`, bypassing the
  gate), so `beachball check` fails on a PR without one. `none` satisfies the
  gate without causing a further bump.

## Why this is safe

The published `0.5.6` is a faithful build of this source:

- Its dependency set matches `packages/babel-preset/package.json` exactly
- No commit has touched the package since `ab3e419d` (2026-07-20), which
  predates the publish

Nothing is republished. After this, `babel-preset` has no pending version
change, so the next release publishes only `babel-test@0.6.7`,
`jest-test@0.9.2` and `webpack@0.5.9`.

## Validation

- `npx beachball bump --scope packages/babel-preset` — lands exactly on `0.5.6`
- `npx projen` — synth preserves the bumped version (the package.json is
  projen-generated, so this was worth confirming)
- `npx beachball check` — passing, run after committing
- Verified the `type: none` file causes no bump: re-running `bump` with it
  present leaves the version at `0.5.6`

## Notes

- `beachball check` still warns about the stale change file for the private
  `@langri-sha/web` package. Pre-existing on `main` and unrelated — left
  untouched, same as in #1107 and #1142.
- The `CHANGELOG.md` entry is stamped with today's bump time rather than the
  15:38:54Z publish time. Cosmetic, and unavoidable when reconstructing the
  entry after the fact.
