### PR TITLE
Group Renovate updates for langri-sha/projen packages

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -88,6 +88,12 @@ const project = new Project({
         matchDatasources: ['terraform-provider'],
         matchPackageNames: ['hashicorp/google*'],
       },
+      {
+        description: 'Packages published from the langri-sha/projen monorepo',
+        groupName: 'langri-sha projen toolchain',
+        groupSlug: 'langri-sha-projen',
+        matchSourceUrls: ['https://github.com/langri-sha/projen'],
+      },
     ],
     customManagers: [
       {

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,12 @@
       matchDatasources: ['terraform-provider'],
       matchPackageNames: ['hashicorp/google*'],
     },
+    {
+      description: 'Packages published from the langri-sha/projen monorepo',
+      groupName: 'langri-sha projen toolchain',
+      groupSlug: 'langri-sha-projen',
+      matchSourceUrls: ['https://github.com/langri-sha/projen'],
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
Renovate delivered langri-sha/projen packages as separate PRs even though beachball publishes them as coupled sets — #1136 and #1140 could not pass CI alone, and #1144 had to take both bumps at once. This groups them into a single PR.

- `renovate.packageRules` entry in `.projenrc.ts`, grouped as `langri-sha projen toolchain`.
- Matches `matchSourceUrls: ['https://github.com/langri-sha/projen']`, not a `@langri-sha/projen-*` glob, so `tsconfig`, `eslint-config`, `prettier`, `lint-staged` and future extractions are covered.

Verified all five packages report `git+https://github.com/langri-sha/projen.git` on npm; clean `npx projen` resynth; `tsc`, eslint, prettier, and `beachball check` pass.

Closes #1147