### PR TITLE
Remove doubled chore(deps) prefix from changelogs

### DIFF
--- a/packages/babel-preset/CHANGELOG.json
+++ b/packages/babel-preset/CHANGELOG.json
@@ -125,13 +125,13 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "dec2a74bd11103d7c193b88247b0de68be347685",
-            "comment": "chore(deps): fix(deps): update dependency @babel/preset-env to v7.25.3"
+            "comment": "fix(deps): update dependency @babel/preset-env to v7.25.3"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "dec2a74bd11103d7c193b88247b0de68be347685",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.14"
+            "comment": "chore(deps): update dependency @types/node to v20.14.14"
           }
         ]
       }
@@ -146,7 +146,7 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "f9d560d2267a0fd1eca8c0375aff72b6a4cc2428",
-            "comment": "chore(deps): fix(deps): update babel monorepo to v7.25.2"
+            "comment": "fix(deps): update babel monorepo to v7.25.2"
           }
         ]
       }
@@ -161,7 +161,7 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "94e0e8e66eadf2c9530c84d1f34fec3b2213b104",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.13"
+            "comment": "chore(deps): update dependency @types/node to v20.14.13"
           }
         ]
       }
@@ -191,19 +191,19 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "d58e2b444358fb65166d0878c185220c6e0a7bb0",
-            "comment": "chore(deps): fix(deps): update dependency @babel/preset-env to v7.25.0"
+            "comment": "fix(deps): update dependency @babel/preset-env to v7.25.0"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "d58e2b444358fb65166d0878c185220c6e0a7bb0",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.12"
+            "comment": "chore(deps): update dependency @types/node to v20.14.12"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "d58e2b444358fb65166d0878c185220c6e0a7bb0",
-            "comment": "chore(deps): fix(deps): update emotion monorepo to v11.12.0"
+            "comment": "fix(deps): update emotion monorepo to v11.12.0"
           }
         ],
         "none": [
@@ -232,7 +232,7 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "c4b7573f367c165d7c67ed5f259ad53ec9ea5672",
-            "comment": "chore(deps): fix(deps): update babel monorepo to v7.24.8"
+            "comment": "fix(deps): update babel monorepo to v7.24.8"
           },
           {
             "author": "filip.dupanovic@gmail.com",
@@ -244,7 +244,7 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "c4b7573f367c165d7c67ed5f259ad53ec9ea5672",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.11"
+            "comment": "chore(deps): update dependency @types/node to v20.14.11"
           }
         ],
         "none": [
@@ -267,43 +267,43 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.5"
+            "comment": "chore(deps): update dependency @types/node to v20.14.5"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.3"
+            "comment": "chore(deps): update dependency @types/node to v20.14.3"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.8"
+            "comment": "chore(deps): update dependency @types/node to v20.14.8"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.10"
+            "comment": "chore(deps): update dependency @types/node to v20.14.10"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update node.js to v20.15.0"
+            "comment": "chore(deps): update node.js to v20.15.0"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.7"
+            "comment": "chore(deps): update dependency @types/node to v20.14.7"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.6"
+            "comment": "chore(deps): update dependency @types/node to v20.14.6"
           }
         ],
         "minor": [
@@ -340,19 +340,19 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "7ac78ea2d172ae9e30f23d213752297fb8436a88",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.2"
+            "comment": "chore(deps): update dependency @types/node to v20.14.2"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "7ac78ea2d172ae9e30f23d213752297fb8436a88",
-            "comment": "chore(deps): fix(deps): update babel monorepo"
+            "comment": "fix(deps): update babel monorepo"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "7ac78ea2d172ae9e30f23d213752297fb8436a88",
-            "comment": "chore(deps): chore(deps): update node.js to v20.14.0"
+            "comment": "chore(deps): update node.js to v20.14.0"
           }
         ],
         "minor": [
@@ -381,7 +381,7 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "92c7d4c9ac50342a39af3fc029307a2899f0ae34",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.12.12"
+            "comment": "chore(deps): update dependency @types/node to v20.12.12"
           }
         ]
       }
@@ -396,13 +396,13 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "bb5eca0acea87c11cf873197bea7383eef3f8465",
-            "comment": "chore(deps): fix(deps): update babel monorepo to v7.24.5"
+            "comment": "fix(deps): update babel monorepo to v7.24.5"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-preset",
             "commit": "bb5eca0acea87c11cf873197bea7383eef3f8465",
-            "comment": "chore(deps): chore(deps): update node.js to v20.13.1"
+            "comment": "chore(deps): update node.js to v20.13.1"
           }
         ]
       }

--- a/packages/babel-preset/CHANGELOG.md
+++ b/packages/babel-preset/CHANGELOG.md
@@ -47,8 +47,8 @@ Thu, 29 Aug 2024 21:44:25 GMT
 
 ### Patches
 
-- chore(deps): fix(deps): update dependency @babel/preset-env to v7.25.3 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.14 (email not defined)
+- fix(deps): update dependency @babel/preset-env to v7.25.3 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.14 (email not defined)
 
 ## 0.5.2
 
@@ -56,7 +56,7 @@ Tue, 30 Jul 2024 08:17:22 GMT
 
 ### Patches
 
-- chore(deps): fix(deps): update babel monorepo to v7.25.2 (email not defined)
+- fix(deps): update babel monorepo to v7.25.2 (email not defined)
 
 ## 0.5.1
 
@@ -64,7 +64,7 @@ Tue, 30 Jul 2024 01:07:42 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.14.13 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.13 (email not defined)
 
 ## 0.5.0
 
@@ -80,9 +80,9 @@ Fri, 26 Jul 2024 21:00:29 GMT
 
 ### Patches
 
-- chore(deps): fix(deps): update dependency @babel/preset-env to v7.25.0 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.12 (email not defined)
-- chore(deps): fix(deps): update emotion monorepo to v11.12.0 (email not defined)
+- fix(deps): update dependency @babel/preset-env to v7.25.0 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.12 (email not defined)
+- fix(deps): update emotion monorepo to v11.12.0 (email not defined)
 
 ## 0.4.1
 
@@ -90,9 +90,9 @@ Wed, 17 Jul 2024 10:48:16 GMT
 
 ### Patches
 
-- chore(deps): fix(deps): update babel monorepo to v7.24.8 (email not defined)
+- fix(deps): update babel monorepo to v7.24.8 (email not defined)
 - fix(workspace): Use correct GitHub directory (filip.dupanovic@gmail.com)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.11 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.11 (email not defined)
 
 ## 0.4.0
 
@@ -104,13 +104,13 @@ Mon, 08 Jul 2024 21:43:05 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.14.5 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.3 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.8 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.10 (email not defined)
-- chore(deps): chore(deps): update node.js to v20.15.0 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.7 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.6 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.5 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.3 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.8 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.10 (email not defined)
+- chore(deps): update node.js to v20.15.0 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.7 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.6 (email not defined)
 
 ## 0.3.0
 
@@ -123,9 +123,9 @@ Sat, 15 Jun 2024 09:09:06 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.14.2 (email not defined)
-- chore(deps): fix(deps): update babel monorepo (email not defined)
-- chore(deps): chore(deps): update node.js to v20.14.0 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.2 (email not defined)
+- fix(deps): update babel monorepo (email not defined)
+- chore(deps): update node.js to v20.14.0 (email not defined)
 
 ## 0.2.4
 
@@ -133,7 +133,7 @@ Wed, 15 May 2024 06:47:18 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.12.12 (email not defined)
+- chore(deps): update dependency @types/node to v20.12.12 (email not defined)
 
 ## 0.2.3
 
@@ -141,8 +141,8 @@ Tue, 14 May 2024 20:41:06 GMT
 
 ### Patches
 
-- chore(deps): fix(deps): update babel monorepo to v7.24.5 (email not defined)
-- chore(deps): chore(deps): update node.js to v20.13.1 (email not defined)
+- fix(deps): update babel monorepo to v7.24.5 (email not defined)
+- chore(deps): update node.js to v20.13.1 (email not defined)
 
 ## 0.2.0
 

--- a/packages/babel-test/CHANGELOG.json
+++ b/packages/babel-test/CHANGELOG.json
@@ -108,7 +108,7 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "dec2a74bd11103d7c193b88247b0de68be347685",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.14"
+            "comment": "chore(deps): update dependency @types/node to v20.14.14"
           }
         ]
       }
@@ -123,7 +123,7 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "94e0e8e66eadf2c9530c84d1f34fec3b2213b104",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.13"
+            "comment": "chore(deps): update dependency @types/node to v20.14.13"
           }
         ]
       }
@@ -153,7 +153,7 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "d58e2b444358fb65166d0878c185220c6e0a7bb0",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.12"
+            "comment": "chore(deps): update dependency @types/node to v20.14.12"
           }
         ],
         "none": [
@@ -188,7 +188,7 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "c4b7573f367c165d7c67ed5f259ad53ec9ea5672",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.11"
+            "comment": "chore(deps): update dependency @types/node to v20.14.11"
           }
         ],
         "none": [
@@ -217,13 +217,13 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.5"
+            "comment": "chore(deps): update dependency @types/node to v20.14.5"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update node.js to v20.15.0"
+            "comment": "chore(deps): update node.js to v20.15.0"
           },
           {
             "author": "filip.dupanovic@gmail.com",
@@ -235,37 +235,37 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.6"
+            "comment": "chore(deps): update dependency @types/node to v20.14.6"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/ramda to v0.30.1"
+            "comment": "chore(deps): update dependency @types/ramda to v0.30.1"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.3"
+            "comment": "chore(deps): update dependency @types/node to v20.14.3"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.10"
+            "comment": "chore(deps): update dependency @types/node to v20.14.10"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.7"
+            "comment": "chore(deps): update dependency @types/node to v20.14.7"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.8"
+            "comment": "chore(deps): update dependency @types/node to v20.14.8"
           }
         ],
         "none": [
@@ -328,19 +328,19 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "7ac78ea2d172ae9e30f23d213752297fb8436a88",
-            "comment": "chore(deps): chore(deps): update node.js to v20.14.0"
+            "comment": "chore(deps): update node.js to v20.14.0"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "7ac78ea2d172ae9e30f23d213752297fb8436a88",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.2"
+            "comment": "chore(deps): update dependency @types/node to v20.14.2"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "7ac78ea2d172ae9e30f23d213752297fb8436a88",
-            "comment": "chore(deps): fix(deps): update dependency ramda to v0.30.1"
+            "comment": "fix(deps): update dependency ramda to v0.30.1"
           }
         ]
       }
@@ -370,7 +370,7 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "92c7d4c9ac50342a39af3fc029307a2899f0ae34",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.12.12"
+            "comment": "chore(deps): update dependency @types/node to v20.12.12"
           }
         ]
       }
@@ -385,13 +385,13 @@
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "bb5eca0acea87c11cf873197bea7383eef3f8465",
-            "comment": "chore(deps): fix(deps): update dependency ramda to v0.30.0"
+            "comment": "fix(deps): update dependency ramda to v0.30.0"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/babel-test",
             "commit": "bb5eca0acea87c11cf873197bea7383eef3f8465",
-            "comment": "chore(deps): chore(deps): update node.js to v20.13.1"
+            "comment": "chore(deps): update node.js to v20.13.1"
           }
         ]
       }

--- a/packages/babel-test/CHANGELOG.md
+++ b/packages/babel-test/CHANGELOG.md
@@ -39,7 +39,7 @@ Thu, 29 Aug 2024 21:44:25 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.14.14 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.14 (email not defined)
 
 ## 0.6.3
 
@@ -47,7 +47,7 @@ Tue, 30 Jul 2024 01:07:42 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.14.13 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.13 (email not defined)
 
 ## 0.6.2
 
@@ -55,7 +55,7 @@ Fri, 26 Jul 2024 21:00:29 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.14.12 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.12 (email not defined)
 
 ## 0.6.1
 
@@ -64,7 +64,7 @@ Wed, 17 Jul 2024 10:48:16 GMT
 ### Patches
 
 - fix(workspace): Use correct GitHub directory (filip.dupanovic@gmail.com)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.11 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.11 (email not defined)
 
 ## 0.6.0
 
@@ -76,15 +76,15 @@ Mon, 08 Jul 2024 21:43:05 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.14.5 (email not defined)
-- chore(deps): chore(deps): update node.js to v20.15.0 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.5 (email not defined)
+- chore(deps): update node.js to v20.15.0 (email not defined)
 - fix(projen): Use correct output directory (filip.dupanovic@gmail.com)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.6 (email not defined)
-- chore(deps): chore(deps): update dependency @types/ramda to v0.30.1 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.3 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.10 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.7 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.8 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.6 (email not defined)
+- chore(deps): update dependency @types/ramda to v0.30.1 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.3 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.10 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.7 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.8 (email not defined)
 
 ## 0.5.0
 
@@ -98,9 +98,9 @@ Sat, 15 Jun 2024 09:09:06 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update node.js to v20.14.0 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.2 (email not defined)
-- chore(deps): fix(deps): update dependency ramda to v0.30.1 (email not defined)
+- chore(deps): update node.js to v20.14.0 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.2 (email not defined)
+- fix(deps): update dependency ramda to v0.30.1 (email not defined)
 
 ## 0.4.0
 
@@ -116,7 +116,7 @@ Wed, 15 May 2024 06:47:18 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.12.12 (email not defined)
+- chore(deps): update dependency @types/node to v20.12.12 (email not defined)
 
 ## 0.3.2
 
@@ -124,8 +124,8 @@ Tue, 14 May 2024 20:41:06 GMT
 
 ### Patches
 
-- chore(deps): fix(deps): update dependency ramda to v0.30.0 (email not defined)
-- chore(deps): chore(deps): update node.js to v20.13.1 (email not defined)
+- fix(deps): update dependency ramda to v0.30.0 (email not defined)
+- chore(deps): update node.js to v20.13.1 (email not defined)
 
 ## 0.3.1
 

--- a/packages/jest-config/CHANGELOG.json
+++ b/packages/jest-config/CHANGELOG.json
@@ -165,7 +165,7 @@
             "author": "email not defined",
             "package": "@langri-sha/jest-config",
             "commit": "bb5eca0acea87c11cf873197bea7383eef3f8465",
-            "comment": "chore(deps): chore(deps): update dependency jest to v29"
+            "comment": "chore(deps): update dependency jest to v29"
           }
         ]
       }

--- a/packages/jest-config/CHANGELOG.md
+++ b/packages/jest-config/CHANGELOG.md
@@ -43,7 +43,7 @@ Tue, 14 May 2024 20:41:06 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency jest to v29 (email not defined)
+- chore(deps): update dependency jest to v29 (email not defined)
 
 ## 0.6.1
 

--- a/packages/webpack/CHANGELOG.json
+++ b/packages/webpack/CHANGELOG.json
@@ -156,7 +156,7 @@
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "dec2a74bd11103d7c193b88247b0de68be347685",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.14"
+            "comment": "chore(deps): update dependency @types/node to v20.14.14"
           }
         ]
       }
@@ -171,7 +171,7 @@
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "94e0e8e66eadf2c9530c84d1f34fec3b2213b104",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.13"
+            "comment": "chore(deps): update dependency @types/node to v20.14.13"
           }
         ]
       }
@@ -201,7 +201,7 @@
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "d58e2b444358fb65166d0878c185220c6e0a7bb0",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.12"
+            "comment": "chore(deps): update dependency @types/node to v20.14.12"
           }
         ],
         "none": [
@@ -250,7 +250,7 @@
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "c4b7573f367c165d7c67ed5f259ad53ec9ea5672",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.11"
+            "comment": "chore(deps): update dependency @types/node to v20.14.11"
           }
         ]
       }
@@ -271,43 +271,43 @@
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.5"
+            "comment": "chore(deps): update dependency @types/node to v20.14.5"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.6"
+            "comment": "chore(deps): update dependency @types/node to v20.14.6"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.3"
+            "comment": "chore(deps): update dependency @types/node to v20.14.3"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update node.js to v20.15.0"
+            "comment": "chore(deps): update node.js to v20.15.0"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.7"
+            "comment": "chore(deps): update dependency @types/node to v20.14.7"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.10"
+            "comment": "chore(deps): update dependency @types/node to v20.14.10"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "94472e1a79e065f4ef9c4e668453e9266b428281",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.8"
+            "comment": "chore(deps): update dependency @types/node to v20.14.8"
           }
         ],
         "none": [
@@ -376,13 +376,13 @@
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "7ac78ea2d172ae9e30f23d213752297fb8436a88",
-            "comment": "chore(deps): chore(deps): update node.js to v20.14.0"
+            "comment": "chore(deps): update node.js to v20.14.0"
           },
           {
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "7ac78ea2d172ae9e30f23d213752297fb8436a88",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.14.2"
+            "comment": "chore(deps): update dependency @types/node to v20.14.2"
           }
         ]
       }
@@ -397,7 +397,7 @@
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "92c7d4c9ac50342a39af3fc029307a2899f0ae34",
-            "comment": "chore(deps): chore(deps): update dependency @types/node to v20.12.12"
+            "comment": "chore(deps): update dependency @types/node to v20.12.12"
           }
         ]
       }
@@ -412,7 +412,7 @@
             "author": "email not defined",
             "package": "@langri-sha/webpack",
             "commit": "bb5eca0acea87c11cf873197bea7383eef3f8465",
-            "comment": "chore(deps): chore(deps): update node.js to v20.13.1"
+            "comment": "chore(deps): update node.js to v20.13.1"
           }
         ]
       }

--- a/packages/webpack/CHANGELOG.md
+++ b/packages/webpack/CHANGELOG.md
@@ -48,7 +48,7 @@ Thu, 29 Aug 2024 21:44:25 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.14.14 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.14 (email not defined)
 
 ## 0.5.4
 
@@ -56,7 +56,7 @@ Tue, 30 Jul 2024 01:07:42 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.14.13 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.13 (email not defined)
 
 ## 0.5.2
 
@@ -64,7 +64,7 @@ Fri, 26 Jul 2024 21:00:29 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.14.12 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.12 (email not defined)
 
 ## 0.5.1
 
@@ -73,7 +73,7 @@ Wed, 17 Jul 2024 10:48:16 GMT
 ### Patches
 
 - fix(workspace): Use correct GitHub directory (filip.dupanovic@gmail.com)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.11 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.11 (email not defined)
 
 ## 0.5.0
 
@@ -86,13 +86,13 @@ Mon, 08 Jul 2024 21:43:04 GMT
 ### Patches
 
 - fix(projen): Use correct output directory (filip.dupanovic@gmail.com)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.5 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.6 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.3 (email not defined)
-- chore(deps): chore(deps): update node.js to v20.15.0 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.7 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.10 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.8 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.5 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.6 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.3 (email not defined)
+- chore(deps): update node.js to v20.15.0 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.7 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.10 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.8 (email not defined)
 
 ## 0.4.0
 
@@ -107,8 +107,8 @@ Sat, 15 Jun 2024 09:09:05 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update node.js to v20.14.0 (email not defined)
-- chore(deps): chore(deps): update dependency @types/node to v20.14.2 (email not defined)
+- chore(deps): update node.js to v20.14.0 (email not defined)
+- chore(deps): update dependency @types/node to v20.14.2 (email not defined)
 
 ## 0.3.3
 
@@ -116,7 +116,7 @@ Wed, 15 May 2024 06:47:18 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update dependency @types/node to v20.12.12 (email not defined)
+- chore(deps): update dependency @types/node to v20.12.12 (email not defined)
 
 ## 0.3.2
 
@@ -124,7 +124,7 @@ Tue, 14 May 2024 20:41:06 GMT
 
 ### Patches
 
-- chore(deps): chore(deps): update node.js to v20.13.1 (email not defined)
+- chore(deps): update node.js to v20.13.1 (email not defined)
 
 ## 0.3.1
 


### PR DESCRIPTION
The old packages workflow prepended `chore(deps): ` to Renovate commit messages that already carried their own conventional-commit prefix, producing entries like `chore(deps): chore(deps): update dependency jest to v29`. The workflow was fixed upstream in langri-sha/github#16; this is a one-time cleanup of the 112 entries it already wrote.

Closes #908