### PR TITLE
Update dependency tempy to v3

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -323,7 +323,7 @@ project.addSubproject(
       ...pkg,
       copyrightYear: '2024',
       type: 'module',
-      deps: ['@jest/globals@29.7.0', 'nock@14.0.16', 'tempy@1.0.1'],
+      deps: ['@jest/globals@29.7.0', 'nock@14.0.16', 'tempy@3.2.0'],
       peerDeps: ['jest@^29.0.0'],
     },
   },

--- a/change/@langri-sha-jest-test-5009587d-0a00-4334-8016-aa4df869855b.json
+++ b/change/@langri-sha-jest-test-5009587d-0a00-4334-8016-aa4df869855b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Update dependency tempy to v3",
+  "packageName": "@langri-sha/jest-test",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-jest-test-e42a2415-7709-4bb4-910b-c3df53de0531.json
+++ b/change/@langri-sha-jest-test-e42a2415-7709-4bb4-910b-c3df53de0531.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Re-export tempy's v3 named API (`temporaryFile`, `temporaryDirectory`, …) instead of the removed default export",
+  "packageName": "@langri-sha/jest-test",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/jest-test/.projen/deps.json
+++ b/packages/jest-test/.projen/deps.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "tempy",
-      "version": "1.0.1",
+      "version": "3.2.0",
       "type": "runtime"
     }
   ],

--- a/packages/jest-test/package.json
+++ b/packages/jest-test/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@jest/globals": "29.7.0",
     "nock": "14.0.16",
-    "tempy": "1.0.1"
+    "tempy": "3.2.0"
   },
   "devDependencies": {
     "@langri-sha/tsconfig": "^0.11.0"

--- a/packages/jest-test/readme.md
+++ b/packages/jest-test/readme.md
@@ -14,10 +14,13 @@ Then import your Jest test dependencies from here:
 
 ```js
 // some.test.js
-import { expect, test, tempy } from '@langri-sha/vitest'
+import { expect, test, temporaryDirectory } from '@langri-sha/jest-test'
 
 test(/*...*/)
 ```
+
+`tempy` is re-exported under its own named API (`temporaryFile`,
+`temporaryDirectory`, `temporaryWrite`, …) rather than as a `tempy` namespace.
 
 ## See
 

--- a/packages/jest-test/src/index.ts
+++ b/packages/jest-test/src/index.ts
@@ -1,3 +1,3 @@
 export * from '@jest/globals'
-export { default as tempy } from 'tempy'
+export * from 'tempy'
 export { default as nock } from 'nock'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,8 +236,8 @@ importers:
         specifier: 14.0.16
         version: 14.0.16
       tempy:
-        specifier: 1.0.1
-        version: 1.0.1
+        specifier: 3.2.0
+        version: 3.2.0
     devDependencies:
       '@langri-sha/tsconfig':
         specifier: ^0.11.0
@@ -3394,6 +3394,10 @@ packages:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
     engines: {node: '>=8'}
 
+  crypto-random-string@4.0.0:
+    resolution: {integrity: sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==}
+    engines: {node: '>=12'}
+
   css-select@4.3.0:
     resolution: {integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==}
 
@@ -5873,9 +5877,17 @@ packages:
     resolution: {integrity: sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==}
     engines: {node: '>=8'}
 
+  temp-dir@3.0.0:
+    resolution: {integrity: sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==}
+    engines: {node: '>=14.16'}
+
   tempy@1.0.1:
     resolution: {integrity: sha512-biM9brNqxSc04Ee71hzFbryD11nX7VPhQQY32AdDmjFvodsRFz/3ufeoTZ6uYkRFfGo188tENcASNs3vTdsM0w==}
     engines: {node: '>=10'}
+
+  tempy@3.2.0:
+    resolution: {integrity: sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==}
+    engines: {node: '>=14.16'}
 
   terser-webpack-plugin@5.6.1:
     resolution: {integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==}
@@ -6029,6 +6041,14 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
+  type-fest@1.4.0:
+    resolution: {integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==}
+    engines: {node: '>=10'}
+
+  type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
     engines: {node: '>=16'}
@@ -6106,6 +6126,10 @@ packages:
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
+
+  unique-string@3.0.0:
+    resolution: {integrity: sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==}
+    engines: {node: '>=12'}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -9647,6 +9671,10 @@ snapshots:
 
   crypto-random-string@2.0.0: {}
 
+  crypto-random-string@4.0.0:
+    dependencies:
+      type-fest: 1.4.0
+
   css-select@4.3.0:
     dependencies:
       boolbase: 1.0.0
@@ -12556,6 +12584,8 @@ snapshots:
 
   temp-dir@2.0.0: {}
 
+  temp-dir@3.0.0: {}
+
   tempy@1.0.1:
     dependencies:
       del: 6.1.1
@@ -12563,6 +12593,13 @@ snapshots:
       temp-dir: 2.0.0
       type-fest: 0.16.0
       unique-string: 2.0.0
+
+  tempy@3.2.0:
+    dependencies:
+      is-stream: 3.0.0
+      temp-dir: 3.0.0
+      type-fest: 2.19.0
+      unique-string: 3.0.0
 
   terser-webpack-plugin@5.6.1(@swc/core@1.15.40)(webpack@5.109.0(@swc/core@1.15.40)(webpack-cli@5.1.4)):
     dependencies:
@@ -12659,6 +12696,10 @@ snapshots:
 
   type-fest@0.21.3: {}
 
+  type-fest@1.4.0: {}
+
+  type-fest@2.19.0: {}
+
   type-fest@4.41.0: {}
 
   type-is@1.6.18:
@@ -12749,6 +12790,10 @@ snapshots:
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
+
+  unique-string@3.0.0:
+    dependencies:
+      crypto-random-string: 4.0.0
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
Supersedes #1169, which this branch is built on — it carries Renovate's two
commits plus the migration needed to make them type-check.

## Problem

`packages/jest-test/src/index.ts` re-exported tempy's default export. Tempy v1
was CommonJS shipping a single default object; v3 is pure ESM with no default
export at all, so the `check / Lint` job failed:

```
packages/jest-test/src/index.ts(2,10): error TS2305:
  Module "tempy" has no exported member "default"
```

Only Lint caught it — it's the one job that type-checks. Vitest skips these
packages and the web build doesn't reference `@langri-sha/jest-test`.

## Fix

Re-export tempy's named API with `export *`, matching how this barrel already
flattens `@jest/globals`:

```ts
export * from '@jest/globals'
export * from 'tempy'
export { default as nock } from 'nock'
```

The v3 names are self-namespacing, so all eight bindings map 1:1 onto the v1
surface — `temporaryFile`/`temporaryFileTask`/`temporaryDirectory`/
`temporaryDirectoryTask`/`temporaryWrite`/`temporaryWriteTask`/
`temporaryWriteSync`/`rootTemporaryDirectory` replace
`file`/`file.task`/`directory`/`directory.task`/`write`/`write.task`/
`writeSync`/`root`. Verified at runtime against the built ESM output.

This was the only tempy usage in the repo — everything else Renovate touched
was metadata (`.projenrc.ts`, `.projen/deps.json`, `package.json`, lockfile).

## Breaking change for consumers

This alters the published export surface: `import { tempy }` no longer
resolves, and call sites move from `tempy.directory()` to
`temporaryDirectory()`. Renovate's change file was `patch`, which would have
shipped that silently, so this adds a `minor` entry alongside it. Beachball
takes the higher of the two.

## Validation

From a clean `pnpm install --frozen-lockfile`: `pnpm tsc --build .`, `eslint .`,
`prettier --check .`, `vitest run`, `beachball check`, and `npx projen`
(idempotent — no generated-artifact drift) all pass.

## Follow-up

`@langri-sha/vitest` has the identical `export { default as tempy }` pattern and
is still on tempy 1.0.1 in `langri-sha/projen`. It will hit this same failure
when Renovate bumps it there.