### PR TITLE
Resolve the Terraform version from required_version alone

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    uses: langri-sha/github/.github/workflows/packages.yml@v0.14.0
+    uses: langri-sha/github/.github/workflows/packages.yml@v0.14.1
     with:
       environment: release
       scope: '@langri-sha'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Run checks
-        uses: langri-sha/github/actions/terraform@v0.14.0
+        uses: langri-sha/github/actions/terraform@v0.14.1
         with:
-          terraform-version: 1.15.8
+          fail-on-unresolved-version: true
           working-directory: ${{ matrix.working-directory }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup PNPM
-        uses: langri-sha/github/actions/pnpm@v0.14.0
+        uses: langri-sha/github/actions/pnpm@v0.14.1
 
       - name: Build
         run: pnpm build
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Google Cloud Platform
-        uses: langri-sha/github/actions/google-cloud-platform@v0.14.0
+        uses: langri-sha/github/actions/google-cloud-platform@v0.14.1
         with:
           service_account: ${{ vars.SERVICE_ACCOUNT }}
           setup_gcloud: true

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    uses: langri-sha/github/.github/workflows/check.yml@v0.14.0
+    uses: langri-sha/github/.github/workflows/check.yml@v0.14.1
     with:
       beachball: true
       eslint: true

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -109,20 +109,6 @@ const project = new Project({
         managerFilePatterns: ['/^packages/eslint-config/src/index\\.js$/'],
         matchStrings: ["react:\\s*\\{\\s*version:\\s*'(?<currentValue>[^']+)'"],
       },
-      {
-        // Keep the Terraform CI workflow pin in lockstep with `required_version`.
-        // The `langri-sha/github` terraform action installs latest when version
-        // auto-detection fails, so `terraform-version` must track the configured
-        // Terraform release. Matching depName/datasource/versioning to the built-in
-        // `required_version` manager lands this on the same Renovate branch as the
-        // Dockerfile and `versions.tf` bumps.
-        customType: 'regex',
-        datasourceTemplate: 'github-releases',
-        depNameTemplate: 'hashicorp/terraform',
-        versioningTemplate: 'hashicorp',
-        managerFilePatterns: ['/^\\.github/workflows/terraform\\.yml$/'],
-        matchStrings: ['terraform-version:\\s*(?<currentValue>\\S+)'],
-      },
     ],
   },
   swcrc: {},

--- a/renovate.json5
+++ b/renovate.json5
@@ -90,13 +90,5 @@
       managerFilePatterns: ['/^packages/eslint-config/src/index\\.js$/'],
       matchStrings: ["react:\\s*\\{\\s*version:\\s*'(?<currentValue>[^']+)'"],
     },
-    {
-      customType: 'regex',
-      datasourceTemplate: 'github-releases',
-      depNameTemplate: 'hashicorp/terraform',
-      versioningTemplate: 'hashicorp',
-      managerFilePatterns: ['/^\\.github/workflows/terraform\\.yml$/'],
-      matchStrings: ['terraform-version:\\s*(?<currentValue>\\S+)'],
-    },
   ],
 }


### PR DESCRIPTION
The `langri-sha/github` terraform action autodetects the Terraform version from `required_version` in the working directory. That detection was silently broken: `rg` ran with no path argument, so it searched **stdin** instead of the directory. A GitHub Actions `run:` step supplies a pipe, ripgrep treats a pipe as searchable, the pipe is empty -- so it matched nothing, exited quietly, and the action fell back to installing `latest`.

Fixed in langri-sha/github#92 (root cause in langri-sha/github#73), released as v0.14.1.

We worked around that bug by pinning `terraform-version:` in the workflow **and** carrying a Renovate custom manager to keep the pin in lockstep with `required_version`. Two sources of truth for one version is exactly the drift that broke langri-sha/github-repos#3. This drops both, so the version lives only in the Terraform sources.

## Changes

- **Remove the `terraform-version:` input** from the `actions/terraform` step. Detection now resolves `1.15.8` from `terraform/web/versions.tf`.
- **Add `fail-on-unresolved-version: true`** so a future detection failure stops the run instead of quietly installing `latest`. This is the input deferred in langri-sha/github#82 when we bumped to v0.13.1.
- **Remove the Renovate custom manager** that synced the workflow pin with `required_version`. With no pin left it would match nothing and sit there as a dead rule. Removed in `.projenrc.ts` and re-synthed into `renovate.json5`; the React version-pin manager is untouched.
- **Bump every `langri-sha/github` reference to v0.14.1** so the repo is on one version: the `terraform`, `pnpm` and `google-cloud-platform` composite actions, and the `check.yml` and `packages.yml` reusable workflows.

## Verification

The `working-directory` matrix has a single leg, `terraform/web`, and `terraform/web/versions.tf` declares `required_version = "1.15.8"` -- so every leg can resolve a version. No `required_version` value was touched.

The evidence to check on this PR is the Terraform job's Setup step: `terraform_version:` must read `1.15.8`, not `latest`.