### PR TITLE
Delete stale beachball change file for private @langri-sha/web

### DIFF
--- a/change/@langri-sha-web-83ad36b6-753d-40b5-80e7-c40c38f74f4a.json
+++ b/change/@langri-sha-web-83ad36b6-753d-40b5-80e7-c40c38f74f4a.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix(deps): regenerate pnpm lockfile to match next 14.2.10",
-  "packageName": "@langri-sha/web",
-  "email": "filip.dupanovic@gmail.com",
-  "dependentChangeType": "patch"
-}


### PR DESCRIPTION
## Summary

Deletes `change/@langri-sha-web-83ad36b6-753d-40b5-80e7-c40c38f74f4a.json`. It
described a patch to `@langri-sha/web`, which is `"private": true`, so beachball
never bumps or publishes it — the file could never be consumed and only produced
a warning on every run. Beachball named the fix itself.

It was the only change file in `change/` pointing at a private package; the
other 19 all target publishable `packages/*`, which is the correct pattern.

## Verification

`npx beachball check` before, on `main`:

```
Validating options and change files...
Change detected for private package @langri-sha/web; delete this file: .../change/@langri-sha-web-83ad36b6-....json
Checking for changes against "origin/main"
```

and after, on this branch:

```
Validating options and change files...
Checking for changes against "origin/main"
```

Both exit 0 — this was always cosmetic and blocked nothing.

One correction to the issue: it quoted `Skipping bumping private package
"@langri-sha/web"` as part of the same warning, but that line appears on `main`
*and* on this branch. Beachball emits it for any private package in the
workspace during the dependency walk, independent of change files, so it is not
removable by deleting this file and is not a defect.

## Test plan

- `npx beachball check` exits 0 with no `delete this file` line
- No other change file targets a private package (all five remaining targets —
  `babel-preset`, `babel-test`, `jest-config`, `jest-test`, `webpack` — are
  publishable)

Closes #1176