### PR TITLE
Bump @langri-sha/tsconfig to v1 and @langri-sha/projen-project to v0.21

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -150,7 +150,7 @@ const subproject = (project: Project) => {
 
   project
     .tryFindObjectFile('package.json')
-    ?.addOverride('devDependencies.@langri-sha/tsconfig', '^0.11.0')
+    ?.addOverride('devDependencies.@langri-sha/tsconfig', '^1.0.0')
 }
 
 const test = (project: Project) => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@langri-sha/babel-preset": "workspace:*",
-    "@langri-sha/tsconfig": "^0.11.0",
+    "@langri-sha/tsconfig": "^1.0.0",
     "@langri-sha/webpack": "workspace:*",
     "@types/gtag.js": "0.0.20",
     "@types/react": "19.2.17",

--- a/change/@langri-sha-babel-preset-2af7fb75-e943-4925-919c-4f02e64a5f7b.json
+++ b/change/@langri-sha-babel-preset-2af7fb75-e943-4925-919c-4f02e64a5f7b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @langri-sha/tsconfig to v1.0.0",
+  "packageName": "@langri-sha/babel-preset",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@langri-sha-babel-test-23b4b799-454f-4deb-bebd-e1e59b65a1a7.json
+++ b/change/@langri-sha-babel-test-23b4b799-454f-4deb-bebd-e1e59b65a1a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @langri-sha/tsconfig to v1.0.0",
+  "packageName": "@langri-sha/babel-test",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@langri-sha-jest-config-ed1b2095-69ad-439a-9d0a-58d6b43f9bad.json
+++ b/change/@langri-sha-jest-config-ed1b2095-69ad-439a-9d0a-58d6b43f9bad.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @langri-sha/tsconfig to v1.0.0",
+  "packageName": "@langri-sha/jest-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@langri-sha-jest-test-aa475470-64b8-407a-b5e3-452ec088fe5b.json
+++ b/change/@langri-sha-jest-test-aa475470-64b8-407a-b5e3-452ec088fe5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @langri-sha/tsconfig to v1.0.0",
+  "packageName": "@langri-sha/jest-test",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@langri-sha-webpack-af41b163-42cb-41cc-9a94-d1868bc40a2e.json
+++ b/change/@langri-sha-webpack-af41b163-42cb-41cc-9a94-d1868bc40a2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Bump @langri-sha/tsconfig to v1.0.0",
+  "packageName": "@langri-sha/webpack",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@langri-sha/prettier": "^0.4.1",
     "@langri-sha/projen-project": "0.21.0",
     "@langri-sha/schemastore-to-typescript": "^0.2.1",
-    "@langri-sha/tsconfig": "^0.11.0",
+    "@langri-sha/tsconfig": "^1.0.0",
     "@swc-node/register": "1.11.1",
     "@swc/core": "1.15.40",
     "@types/node": "26.1.1",

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@langri-sha/babel-test": "workspace:*",
-    "@langri-sha/tsconfig": "^0.11.0",
+    "@langri-sha/tsconfig": "^1.0.0",
     "@langri-sha/vitest": "^0.1.2",
     "@types/node": "26.1.1"
   },

--- a/packages/babel-test/package.json
+++ b/packages/babel-test/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@langri-sha/monorepo": "^0.5.7",
-    "@langri-sha/tsconfig": "^0.11.0",
+    "@langri-sha/tsconfig": "^1.0.0",
     "@langri-sha/vitest": "^0.1.2",
     "@types/node": "26.1.1",
     "@types/ramda": "0.32.0"

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@fontsource/cinzel-decorative": "5.3.0",
-    "@langri-sha/tsconfig": "^0.11.0",
+    "@langri-sha/tsconfig": "^1.0.0",
     "@types/node": "26.1.1",
     "subset-font": "2.5.0"
   },

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -22,7 +22,7 @@
     "prepublishOnly": "rm -rf dist; tsc --project tsconfig.build.json"
   },
   "devDependencies": {
-    "@langri-sha/tsconfig": "^0.11.0"
+    "@langri-sha/tsconfig": "^1.0.0"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/jest-test/package.json
+++ b/packages/jest-test/package.json
@@ -27,7 +27,7 @@
     "tempy": "3.2.0"
   },
   "devDependencies": {
-    "@langri-sha/tsconfig": "^0.11.0"
+    "@langri-sha/tsconfig": "^1.0.0"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@langri-sha/babel-preset": "workspace:*",
-    "@langri-sha/tsconfig": "^0.11.0",
+    "@langri-sha/tsconfig": "^1.0.0",
     "@types/node": "26.1.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,8 +49,8 @@ importers:
         specifier: ^0.2.1
         version: 0.2.4(projen@0.86.5(constructs@10.7.1))
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.9.3)
       '@swc-node/register':
         specifier: 1.11.1
         version: 1.11.1(@swc/core@1.15.40)(@swc/types@0.1.27)(typescript@5.9.3)
@@ -119,8 +119,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/babel-preset
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.9.3)
       '@langri-sha/webpack':
         specifier: workspace:*
         version: link:../../packages/webpack
@@ -165,8 +165,8 @@ importers:
         specifier: workspace:*
         version: link:../babel-test
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.9.3)
       '@langri-sha/vitest':
         specifier: ^0.1.2
         version: 0.1.5(vitest@2.1.9(@types/node@26.1.1)(terser@5.49.0))
@@ -187,8 +187,8 @@ importers:
         specifier: ^0.5.7
         version: 0.5.11
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.9.3)
       '@langri-sha/vitest':
         specifier: ^0.1.2
         version: 0.1.5(vitest@2.1.9(@types/node@26.1.1)(terser@5.49.0))
@@ -205,8 +205,8 @@ importers:
         specifier: 5.3.0
         version: 5.3.0
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.9.3)
       '@types/node':
         specifier: 26.1.1
         version: 26.1.1
@@ -221,8 +221,8 @@ importers:
         version: 30.4.2(@types/node@26.1.1)(babel-plugin-macros@3.1.0)
     devDependencies:
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.9.3)
 
   packages/jest-test:
     dependencies:
@@ -240,8 +240,8 @@ importers:
         version: 3.2.0
     devDependencies:
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.9.3)
 
   packages/webpack:
     dependencies:
@@ -280,8 +280,8 @@ importers:
         specifier: workspace:*
         version: link:../babel-preset
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.9.3)
       '@types/node':
         specifier: 26.1.1
         version: 26.1.1
@@ -2002,8 +2002,8 @@ packages:
     peerDependencies:
       projen: ^0.86.0
 
-  '@langri-sha/tsconfig@0.11.1':
-    resolution: {integrity: sha512-ipi2Kirxg6xSwEDztQWInnDpPxSOYy5zFveC3ud0OeaxqCW0cmTd3xZmbZYS65yCL3zwzDEbwv0RZ16s8ObNBg==}
+  '@langri-sha/tsconfig@1.0.0':
+    resolution: {integrity: sha512-z4yMVs4SZNwt6CUakx2nqa12E4oDisU6X9Bl9acEvvg6FDl6uQ/MJ2Rl8WBD9alRcHqyRvBvz/cVjFeZf30SBA==}
     peerDependencies:
       typescript: ^5.5.0
 
@@ -8191,7 +8191,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@langri-sha/tsconfig@0.11.1(typescript@5.9.3)':
+  '@langri-sha/tsconfig@1.0.0(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
 


### PR DESCRIPTION
## Summary

`@langri-sha/tsconfig` had a breaking major release, `1.0.0` (see
[langri-sha/projen#40](https://github.com/langri-sha/projen/issues/40) and the
two producer PRs, [langri-sha/projen#80](https://github.com/langri-sha/projen/pull/80)
and [langri-sha/projen#81](https://github.com/langri-sha/projen/pull/81)):
`react.json` and `emotion.json` went from transitively extending `base.json`
to being pure "aspect" files with no `extends` at all, meant to be combined
with a complete config (`base.json`/`project.json`/`build.json`) via an
`extends` array.

**This repo needs no `extends` changes** — it's a pure dependency version
bump:

- Root `tsconfig.json` and every `packages/*/tsconfig.json` /
  `tsconfig.build.json` extend only `base.json` / `project.json` /
  `build.json`, which are unchanged by the breaking release. None of them
  ever used `react.json` or `emotion.json`.
- `apps/web/tsconfig.json` is the one file that does use `react.json`, via
  `"extends": ["@langri-sha/tsconfig/project.json", "@langri-sha/tsconfig/react.json"]`.
  That's already the idiomatic form under the new structure (previously it
  worked too, just with `react.json` redundantly re-applying `base.json`
  internally). This file is untouched by this PR — it's hand-authored, not
  projen-managed, and needed no change.

`@langri-sha/projen-project` was already bumped to `0.21.0` on `main` by
Renovate before this branch was cut, so this PR only carries the
`@langri-sha/tsconfig` bump.

## Changes

- `.projenrc.ts`: bump the `addOverride('devDependencies.@langri-sha/tsconfig', ...)` pin (shared by all six projen subprojects) from `^0.11.0` to `^1.0.0`.
- Root `package.json`: hand-bump `@langri-sha/tsconfig` to `^1.0.0`. (This entry is governed by projen's "sticky `*`" version resolution rather than a literal in `.projenrc.ts` — projen preserves whatever's already pinned in `package.json` across resyncs, so it's edited directly rather than through a projenrc override.)
- `apps/web/package.json`: hand-bump `@langri-sha/tsconfig` to `^1.0.0` (not projen-managed).
- `pnpm-lock.yaml`: regenerated via `pnpm install`.
- All six `packages/*/package.json` files: regenerated via `pnpm exec projen` and only show the `@langri-sha/tsconfig` version bump.

## Test plan

- [x] `pnpm install` — resolves `@langri-sha/tsconfig` to `1.0.0`, no other version drift.
- [x] `pnpm exec projen` — regenerates all subproject files; diff is version-only, confirmed via `git diff` (no `extends` field touched anywhere, `apps/web/tsconfig.json` byte-identical before/after).
- [x] `pnpm exec projen` run a second time — no-op, confirming idempotency.
- [x] `pnpm exec tsc --build --force` — typechecks clean across the whole project-reference graph, including `apps/web`.
- [x] `pnpm exec eslint .` — clean.
- [x] `pnpm run build` (`next build` for `@langri-sha/web`) — succeeds.
- [x] `pnpm exec vitest run` — runs the two existing (pre-existing `test.skip`, unrelated to this change) suites, no failures.
