### PR TITLE
Install our own packages without waiting them out

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -93,6 +93,11 @@ const project = new Project({
         groupSlug: 'langri-sha-projen',
         matchSourceUrls: ['https://github.com/langri-sha/projen'],
       },
+      {
+        description: 'Install our own packages without waiting them out',
+        matchPackageNames: ['@langri-sha/**'],
+        minimumReleaseAge: null,
+      },
     ],
     customManagers: [
       {

--- a/renovate.json5
+++ b/renovate.json5
@@ -33,6 +33,11 @@
       groupSlug: 'langri-sha-projen',
       matchSourceUrls: ['https://github.com/langri-sha/projen'],
     },
+    {
+      description: 'Install our own packages without waiting them out',
+      matchPackageNames: ['@langri-sha/**'],
+      minimumReleaseAge: null,
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
## Summary

Exempt `@langri-sha/*` packages from the Renovate release-age delay.

The Renovate defaults emitted by `@langri-sha/projen-project` hold every update for three days, so that pnpm — which refuses anything published in the last 24 hours — will still install it once the pull request merges. Neither window does useful work for packages published from `langri-sha/projen`: we are the supply chain being guarded against, and the delay only slows down consuming our own releases.

Refs langri-sha/projen#85.

## How it works

The rule is appended after the emitted defaults, and Renovate applies the **last** matching rule, so it overrides the top-level `minimumReleaseAge` for this scope only. Third-party dependencies keep the full three-day policy, which is where the supply-chain benefit actually lives.

`@scope/**` is Renovate's documented idiom for "any package starting with the scope".

## Scope: Renovate only

The matching pnpm setting (`minimumReleaseAgeExclude` in `pnpm-workspace.yaml`) is deliberately **not** included. `minimumReleaseAge` is a pnpm 10.17+/11 feature and this repository is still on pnpm 9, so that setting would be inert config today. It belongs with the pnpm 11 upgrade (langri-sha/projen#79), where it starts doing something.

The two settings do have to agree once both are live — exempting our packages on one side while the other still holds them back is what originally made Renovate propose updates that `pnpm install` then refused, turning `main` red until the release aged out. Doing the Renovate half now is safe because pnpm 9 has no gate to disagree with.

## Verification

The same change is already merged and proven in `langri-sha/terraform-google-cloud-platform`, the one repository already on pnpm 11 (PR #49). There, CI installed `@langri-sha/projen-project@0.22.1` **twelve minutes after it was published** — against pnpm 11's 24-hour gate, on the `--frozen-lockfile` path that produces `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`. It passed.

## Test plan

- `pnpm exec projen` — regenerates `renovate.json5`; the only change is the added rule, no unrelated churn.
- `prettier --check .` — clean.
