### PR TITLE
Exempt our own GitHub Actions and Terraform modules from minimumReleaseAge

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -105,6 +105,12 @@ const project = new Project({
         matchPackageNames: ['@langri-sha/**'],
         minimumReleaseAge: null,
       },
+      {
+        description:
+          'Install our own GitHub Actions and Terraform modules without waiting them out',
+        matchPackageNames: ['langri-sha/**'],
+        minimumReleaseAge: null,
+      },
     ],
     customManagers: [
       {

--- a/renovate.json5
+++ b/renovate.json5
@@ -38,6 +38,11 @@
       matchPackageNames: ['@langri-sha/**'],
       minimumReleaseAge: null,
     },
+    {
+      description: 'Install our own GitHub Actions and Terraform modules without waiting them out',
+      matchPackageNames: ['langri-sha/**'],
+      minimumReleaseAge: null,
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
## Summary

The existing `@langri-sha/**` packageRules entry that exempts our own npm
packages from `minimumReleaseAge` is npm-scope-shaped and only matches that
one shape. It doesn't cover two other first-party dependency kinds this repo
carries:

- **GitHub Actions** — `.github/workflows/*.yml` references
  `langri-sha/github`, packageName `owner/repo`, no `@` prefix.
- **Terraform modules** — `terraform/web/github.tf` sources a module
  straight from our own repo
  (`github.com/langri-sha/terraform-google-cloud-platform//modules/github?ref=v0.11.0`),
  which Renovate's terraform module extractor normalizes to the same bare
  `owner/repo` packageName shape as the Actions case.

Adds a second `packageRules` entry, `matchPackageNames: ['langri-sha/**']`,
covering both with one rule since they normalize to the same shape.

This is a per-repo hand-edit, not a shared default — the exemption is
specific to this org, so it stays out of `@langri-sha/projen-project`'s
`#configureRenovate` defaults, which unrelated consumers depend on. Mirrors
the reasoning from langri-sha/projen#85.

## Changes

- `.projenrc.ts`: add the `langri-sha/**` packageRules entry
- `renovate.json5`: regenerated via `pnpm exec projen`

## Test plan

- [x] `pnpm exec projen` run twice — byte-identical `renovate.json5`
- [x] Verified with `minimatch` that `langri-sha/**` matches `langri-sha/github`
      and `langri-sha/terraform-google-cloud-platform`, and does NOT match
      third-party packages (`terraform-google-modules/*`, `hashicorp/*`,
      `integrations/github`), which stay covered by the top-level 3-day default
- [x] `npx tsc --build .` — clean
- [x] `npx prettier --check .` — clean
- [x] `npx eslint .` — clean
- [x] `npx vitest run` — passes
- [x] `npx beachball check` — no change files needed (root-config-only change)

Closes #1205