### PR TITLE
Let subprojects track the tsconfig version

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -165,10 +165,6 @@ const subproject = (project: Project) => {
       project.outdir,
     ),
   })
-
-  project
-    .tryFindObjectFile('package.json')
-    ?.addOverride('devDependencies.@langri-sha/tsconfig', '^0.11.0')
 }
 
 const test = (project: Project) => {

--- a/change/@langri-sha-babel-preset-6417d026-db5b-4f03-9b95-55d417259cd7.json
+++ b/change/@langri-sha-babel-preset-6417d026-db5b-4f03-9b95-55d417259cd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Track @langri-sha/tsconfig v1 instead of pinning it via a projen override",
+  "packageName": "@langri-sha/babel-preset",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-babel-test-26999ab1-c828-44e2-abae-d438b7e22a59.json
+++ b/change/@langri-sha-babel-test-26999ab1-c828-44e2-abae-d438b7e22a59.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Track @langri-sha/tsconfig v1 instead of pinning it via a projen override",
+  "packageName": "@langri-sha/babel-test",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-jest-config-6cb74496-1874-47ab-a56e-7ec32f79a9fa.json
+++ b/change/@langri-sha-jest-config-6cb74496-1874-47ab-a56e-7ec32f79a9fa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Track @langri-sha/tsconfig v1 instead of pinning it via a projen override",
+  "packageName": "@langri-sha/jest-config",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-jest-test-f4e55676-301d-47d6-a4a3-ec124138d11f.json
+++ b/change/@langri-sha-jest-test-f4e55676-301d-47d6-a4a3-ec124138d11f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Track @langri-sha/tsconfig v1 instead of pinning it via a projen override",
+  "packageName": "@langri-sha/jest-test",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@langri-sha-webpack-f56c62f7-f12d-4e17-a0aa-dc4aa34a353e.json
+++ b/change/@langri-sha-webpack-f56c62f7-f12d-4e17-a0aa-dc4aa34a353e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Track @langri-sha/tsconfig v1 instead of pinning it via a projen override",
+  "packageName": "@langri-sha/webpack",
+  "email": "filip.dupanovic@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/babel-preset/package.json
+++ b/packages/babel-preset/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "@langri-sha/babel-test": "workspace:*",
-    "@langri-sha/tsconfig": "^0.11.0",
+    "@langri-sha/tsconfig": "^1.0.1",
     "@langri-sha/vitest": "^0.1.2",
     "@types/node": "26.1.1"
   },

--- a/packages/babel-test/package.json
+++ b/packages/babel-test/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "@langri-sha/monorepo": "^0.5.7",
-    "@langri-sha/tsconfig": "^0.11.0",
+    "@langri-sha/tsconfig": "^1.0.1",
     "@langri-sha/vitest": "^0.1.2",
     "@types/node": "26.1.1",
     "@types/ramda": "0.32.0"

--- a/packages/fonts/package.json
+++ b/packages/fonts/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@fontsource/cinzel-decorative": "5.3.0",
-    "@langri-sha/tsconfig": "^0.11.0",
+    "@langri-sha/tsconfig": "^1.0.1",
     "@types/node": "26.1.1",
     "subset-font": "2.5.0"
   },

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -22,7 +22,7 @@
     "prepublishOnly": "rm -rf dist; tsc --project tsconfig.build.json"
   },
   "devDependencies": {
-    "@langri-sha/tsconfig": "^0.11.0"
+    "@langri-sha/tsconfig": "^1.0.1"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/jest-test/package.json
+++ b/packages/jest-test/package.json
@@ -27,7 +27,7 @@
     "tempy": "3.2.0"
   },
   "devDependencies": {
-    "@langri-sha/tsconfig": "^0.11.0"
+    "@langri-sha/tsconfig": "^1.0.1"
   },
   "peerDependencies": {
     "jest": "^30.0.0"

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@langri-sha/babel-preset": "workspace:*",
-    "@langri-sha/tsconfig": "^0.11.0",
+    "@langri-sha/tsconfig": "^1.0.1",
     "@types/node": "26.1.1"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: workspace:*
         version: link:../babel-test
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.1
+        version: 1.0.1(typescript@5.9.3)
       '@langri-sha/vitest':
         specifier: ^0.1.2
         version: 0.1.8(vitest@4.1.10(@types/node@26.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))
@@ -187,8 +187,8 @@ importers:
         specifier: ^0.5.7
         version: 0.5.14
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.1
+        version: 1.0.1(typescript@5.9.3)
       '@langri-sha/vitest':
         specifier: ^0.1.2
         version: 0.1.8(vitest@4.1.10(@types/node@26.1.1)(vite@8.1.5(@types/node@26.1.1)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.23.1)(yaml@2.9.0)))
@@ -205,8 +205,8 @@ importers:
         specifier: 5.3.0
         version: 5.3.0
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.1
+        version: 1.0.1(typescript@5.9.3)
       '@types/node':
         specifier: 26.1.1
         version: 26.1.1
@@ -221,8 +221,8 @@ importers:
         version: 30.4.2(@types/node@26.1.1)(babel-plugin-macros@3.1.0)(supports-color@8.1.1)
     devDependencies:
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.1
+        version: 1.0.1(typescript@5.9.3)
 
   packages/jest-test:
     dependencies:
@@ -240,8 +240,8 @@ importers:
         version: 3.2.0
     devDependencies:
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.1
+        version: 1.0.1(typescript@5.9.3)
 
   packages/webpack:
     dependencies:
@@ -250,38 +250,38 @@ importers:
         version: 8.0.1(@babel/core@8.0.1)
       babel-loader:
         specifier: 10.1.1
-        version: 10.1.1(@babel/core@8.0.1)(webpack@5.109.0)
+        version: 10.1.1(@babel/core@8.0.1)(webpack@5.109.2)
       clean-webpack-plugin:
         specifier: 4.0.0
-        version: 4.0.0(webpack@5.109.0)
+        version: 4.0.0(webpack@5.109.2)
       copy-webpack-plugin:
         specifier: 14.0.0
-        version: 14.0.0(webpack@5.109.0)
+        version: 14.0.0(webpack@5.109.2)
       html-webpack-plugin:
         specifier: 5.6.8
-        version: 5.6.8(webpack@5.109.0)
+        version: 5.6.8(webpack@5.109.2)
       terser-webpack-plugin:
         specifier: 5.6.1
-        version: 5.6.1(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.0)
+        version: 5.6.1(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.2)
       webpack:
         specifier: ^5.0.0
-        version: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
+        version: 5.109.2(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
       webpack-bundle-analyzer:
         specifier: 5.3.1
         version: 5.3.1
       webpack-dev-server:
         specifier: 6.0.0
-        version: 6.0.0(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@7.2.2)(webpack@5.109.0)
+        version: 6.0.0(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@7.2.2)(webpack@5.109.2)
       webpack-subresource-integrity:
         specifier: 5.2.0-rc.1
-        version: 5.2.0-rc.1(html-webpack-plugin@5.6.8(webpack@5.109.0))(webpack@5.109.0)
+        version: 5.2.0-rc.1(html-webpack-plugin@5.6.8(webpack@5.109.2))(webpack@5.109.2)
     devDependencies:
       '@langri-sha/babel-preset':
         specifier: workspace:*
         version: link:../babel-preset
       '@langri-sha/tsconfig':
-        specifier: ^0.11.0
-        version: 0.11.1(typescript@5.9.3)
+        specifier: ^1.0.1
+        version: 1.0.1(typescript@5.9.3)
       '@types/node':
         specifier: 26.1.1
         version: 26.1.1
@@ -1885,11 +1885,6 @@ packages:
     hasBin: true
     peerDependencies:
       projen: ^0.86.0
-
-  '@langri-sha/tsconfig@0.11.1':
-    resolution: {integrity: sha512-ipi2Kirxg6xSwEDztQWInnDpPxSOYy5zFveC3ud0OeaxqCW0cmTd3xZmbZYS65yCL3zwzDEbwv0RZ16s8ObNBg==}
-    peerDependencies:
-      typescript: ^5.5.0
 
   '@langri-sha/tsconfig@1.0.1':
     resolution: {integrity: sha512-edz4jWkTffOpnk/ZslBtfdQs4Cc5bwuRzDhjavoiIkZBaxJvmhURq1gTKuHz+/3fv2kbxuQfyLb402GIJdxr+w==}
@@ -3529,10 +3524,6 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
-
-  enhanced-resolve@5.24.3:
-    resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
-    engines: {node: '>=10.13.0'}
 
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
@@ -6245,16 +6236,6 @@ packages:
       html-webpack-plugin:
         optional: true
 
-  webpack@5.109.0:
-    resolution: {integrity: sha512-vomrngskVVXEZF9sMZfYAd4pXZUnfaWdJGlF+BTNF+gJBCKYCQBnOeVPlrh39Ewl7nlCsirDplMy6o5g9xJHBg==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-
   webpack@5.109.2:
     resolution: {integrity: sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==}
     engines: {node: '>=10.13.0'}
@@ -8142,10 +8123,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@langri-sha/tsconfig@0.11.1(typescript@5.9.3)':
-    dependencies:
-      typescript: 5.9.3
-
   '@langri-sha/tsconfig@1.0.1(typescript@5.9.3)':
     dependencies:
       typescript: 5.9.3
@@ -9251,12 +9228,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@10.1.1(@babel/core@8.0.1)(webpack@5.109.0):
+  babel-loader@10.1.1(@babel/core@8.0.1)(webpack@5.109.2):
     dependencies:
       '@babel/core': 8.0.1
       find-up: 5.0.0
     optionalDependencies:
-      webpack: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
+      webpack: 5.109.2(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
 
   babel-plugin-istanbul@7.0.1(supports-color@8.1.1):
     dependencies:
@@ -9477,10 +9454,10 @@ snapshots:
     dependencies:
       source-map: 0.6.1
 
-  clean-webpack-plugin@4.0.0(webpack@5.109.0):
+  clean-webpack-plugin@4.0.0(webpack@5.109.2):
     dependencies:
       del: 4.1.1
-      webpack: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
+      webpack: 5.109.2(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
 
   client-only@0.0.1: {}
 
@@ -9556,14 +9533,14 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  copy-webpack-plugin@14.0.0(webpack@5.109.0):
+  copy-webpack-plugin@14.0.0(webpack@5.109.2):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.7
       tinyglobby: 0.2.17
-      webpack: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
+      webpack: 5.109.2(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -9751,11 +9728,6 @@ snapshots:
   empathic@2.0.1: {}
 
   encodeurl@2.0.0: {}
-
-  enhanced-resolve@5.24.3:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
 
   enhanced-resolve@5.24.5:
     dependencies:
@@ -10504,7 +10476,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.49.0
 
-  html-webpack-plugin@5.6.8(webpack@5.109.0):
+  html-webpack-plugin@5.6.8(webpack@5.109.2):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -10512,7 +10484,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.3.3
     optionalDependencies:
-      webpack: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
+      webpack: 5.109.2(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -11418,21 +11390,6 @@ snapshots:
       brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
-
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.0):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.49.0
-      webpack: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
-    optionalDependencies:
-      '@swc/core': 1.15.46
-      clean-css: 5.3.3
-      esbuild: 0.28.1
-      html-minifier-terser: 6.1.0
-      lightningcss: 1.33.0
-      postcss: 8.5.23
 
   minimizer-webpack-plugin@5.6.1(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.2):
     dependencies:
@@ -12450,13 +12407,13 @@ snapshots:
       type-fest: 2.19.0
       unique-string: 3.0.0
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.0):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.49.0
-      webpack: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
+      webpack: 5.109.2(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
     optionalDependencies:
       '@swc/core': 1.15.46
       clean-css: 5.3.3
@@ -12763,24 +12720,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-cli@7.2.2(js-yaml@4.3.0)(json5@2.2.3)(webpack-bundle-analyzer@5.3.1)(webpack-dev-server@6.0.0)(webpack@5.109.0):
-    dependencies:
-      '@discoveryjs/json-ext': 1.1.0
-      commander: 14.0.3
-      cross-spawn: 7.0.6
-      envinfo: 7.21.0
-      import-local: 3.2.0
-      interpret: 3.1.1
-      rechoir: 0.8.0
-      webpack: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
-      webpack-merge: 6.0.1
-    optionalDependencies:
-      js-yaml: 4.3.0
-      json5: 2.2.3
-      webpack-bundle-analyzer: 5.3.1
-      webpack-dev-server: 6.0.0(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@7.2.2)(webpack@5.109.0)
-    optional: true
-
   webpack-cli@7.2.2(js-yaml@4.3.0)(json5@2.2.3)(webpack-bundle-analyzer@5.3.1)(webpack-dev-server@6.0.0)(webpack@5.109.2):
     dependencies:
       '@discoveryjs/json-ext': 1.1.0
@@ -12798,17 +12737,6 @@ snapshots:
       webpack-bundle-analyzer: 5.3.1
       webpack-dev-server: 6.0.0(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@7.2.2)(webpack@5.109.2)
 
-  webpack-dev-middleware@8.1.0(tslib@2.8.1)(webpack@5.109.0):
-    dependencies:
-      memfs: 4.64.0(tslib@2.8.1)
-      mime-types: 3.0.2
-      range-parser: 1.3.0
-      schema-utils: 4.3.3
-    optionalDependencies:
-      webpack: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
-    transitivePeerDependencies:
-      - tslib
-
   webpack-dev-middleware@8.1.0(tslib@2.8.1)(webpack@5.109.2):
     dependencies:
       memfs: 4.64.0(tslib@2.8.1)
@@ -12819,43 +12747,6 @@ snapshots:
       webpack: 5.109.2(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
     transitivePeerDependencies:
       - tslib
-    optional: true
-
-  webpack-dev-server@6.0.0(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@7.2.2)(webpack@5.109.0):
-    dependencies:
-      '@types/bonjour': 3.5.13
-      '@types/connect-history-api-fallback': 1.5.4
-      '@types/express': 5.0.6
-      '@types/express-serve-static-core': 5.1.2
-      '@types/serve-index': 1.9.4
-      '@types/serve-static': 2.2.0
-      '@types/ws': 8.18.1
-      ansi-html-community: 0.0.8
-      bonjour-service: 1.4.3
-      chokidar: 5.0.0
-      compression: 1.8.1(supports-color@8.1.1)
-      connect-history-api-fallback: 2.0.0
-      express: 5.2.1(supports-color@8.1.1)
-      graceful-fs: 4.2.11
-      http-proxy-middleware: 4.2.0(supports-color@8.1.1)
-      ipaddr.js: 2.4.0
-      launch-editor: 2.14.1
-      open: 11.0.0
-      p-retry: 8.0.0
-      schema-utils: 4.3.3
-      selfsigned: 5.5.0
-      serve-index: 1.9.2(supports-color@8.1.1)
-      tinyglobby: 0.2.17
-      webpack-dev-middleware: 8.1.0(tslib@2.8.1)(webpack@5.109.0)
-      ws: 8.21.1
-    optionalDependencies:
-      webpack: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
-      webpack-cli: 7.2.2(js-yaml@4.3.0)(json5@2.2.3)(webpack-bundle-analyzer@5.3.1)(webpack-dev-server@6.0.0)(webpack@5.109.0)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - tslib
-      - utf-8-validate
 
   webpack-dev-server@6.0.0(supports-color@8.1.1)(tslib@2.8.1)(webpack-cli@7.2.2)(webpack@5.109.2):
     dependencies:
@@ -12892,7 +12783,6 @@ snapshots:
       - supports-color
       - tslib
       - utf-8-validate
-    optional: true
 
   webpack-merge@6.0.1:
     dependencies:
@@ -12902,49 +12792,11 @@ snapshots:
 
   webpack-sources@3.5.1: {}
 
-  webpack-subresource-integrity@5.2.0-rc.1(html-webpack-plugin@5.6.8(webpack@5.109.0))(webpack@5.109.0):
+  webpack-subresource-integrity@5.2.0-rc.1(html-webpack-plugin@5.6.8(webpack@5.109.2))(webpack@5.109.2):
     dependencies:
-      webpack: 5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
+      webpack: 5.109.2(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2)
     optionalDependencies:
-      html-webpack-plugin: 5.6.8(webpack@5.109.0)
-
-  webpack@5.109.0(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2):
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.17.0
-      browserslist: 4.28.7
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.3
-      es-module-lexer: 2.3.1
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      graceful-fs: 4.2.11
-      mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack@5.109.0)
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      watchpack: 2.5.2
-      webpack-sources: 3.5.1
-    optionalDependencies:
-      webpack-cli: 7.2.2(js-yaml@4.3.0)(json5@2.2.3)(webpack-bundle-analyzer@5.3.1)(webpack-dev-server@6.0.0)(webpack@5.109.0)
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
+      html-webpack-plugin: 5.6.8(webpack@5.109.2)
 
   webpack@5.109.2(@swc/core@1.15.46)(clean-css@5.3.3)(esbuild@0.28.1)(html-minifier-terser@6.1.0)(lightningcss@1.33.0)(postcss@8.5.23)(webpack-cli@7.2.2):
     dependencies:


### PR DESCRIPTION
Closes #1212.

Each published subproject had its `@langri-sha/tsconfig` version forced by an `addOverride` on the generated `package.json`:

```ts
project
  .tryFindObjectFile('package.json')
  ?.addOverride('devDependencies.@langri-sha/tsconfig', '^0.11.0')
```

The preset already supplies the dependency as `*`, which projen resolves from whatever is installed — the same arrangement the root package has always used. The override only pinned it in place.

## Why the upgrade could never land

Renovate raises `packages/*/package.json` to the new range, the next `pnpm projen` re-applies the override, and the PR merges having changed nothing but its own Beachball change files:

```
4ff07f3d  Update dependency @langri-sha/tsconfig to v1
8571ffa9  Update dependency @langri-sha/tsconfig to v1 (#1201)
26909e23  Update dependency @langri-sha/tsconfig to v1 (#1200)
a2ef2b65  Update dependency @langri-sha/tsconfig to v1
5ba3a4bf  Update dependency @langri-sha/tsconfig to v1
```

Five merges, and the version never moved — `main` is still on `^0.11.0`. #1201 landed with a diff of five change files and nothing else. #1212 is the same PR again, and merging it would have added five more `patch` change files describing an upgrade that is not in the diff.

It could not self-correct either. Renovate's projenrc custom managers match `addDeps`, `addDevDeps` and `addPeerDeps` calls — not `addOverride` — so the version behind it was invisible to every bot that might have raised it. This is the same shape as the `@swc/core` loop in #1204, but caused by a raw file override in this repository rather than by a preset feature pin, so `@langri-sha/projen-project` 0.23.0/0.24.0 does nothing for it.

## The change

Drop the override, and install the version the subprojects should be on. Removing the override alone is not enough — projen resolves a `*` dependency from the lockfile, and the subprojects were still resolving their own `^0.11.0` — so this also runs the install that moves them to `^1.0.1`.

They now behave exactly as the root package does: the next upgrade lands by being installed rather than by being fought, and Renovate's npm manager can move them like any other dependency.

`packages/fonts` moves too. It is private, so it takes no change file, but it was subject to the same override.

## Validation

`pnpm projen` produces the new versions and is idempotent on a second run — under the override the same synthesis reverted them, which is what confirms the diagnosis. `prettier --check`, `eslint`, `tsc --build`, `vitest` and `beachball check` all pass.