### PR TITLE
Set up the preview origin on Cloud Run

### DIFF
--- a/terraform/modules/previews/main.tf
+++ b/terraform/modules/previews/main.tf
@@ -4,3 +4,48 @@ resource "google_service_account" "previews" {
   description  = "Runtime identity of the preview origin service. It serves files baked into its own image and holds no roles."
   project      = var.project
 }
+
+resource "google_cloud_run_v2_service" "previews" {
+  name     = "web-previews"
+  location = var.location
+  project  = var.project
+
+  ingress             = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  deletion_protection = false
+
+  template {
+    service_account                  = google_service_account.previews.email
+    max_instance_request_concurrency = 80
+
+    scaling {
+      max_instance_count = 4
+      min_instance_count = 0
+    }
+
+    containers {
+      image = var.image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        cpu_idle = true
+
+        limits = {
+          cpu    = "1"
+          memory = "256Mi"
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+      template[0].containers[0].image,
+      traffic,
+    ]
+  }
+}

--- a/terraform/modules/previews/main.tf
+++ b/terraform/modules/previews/main.tf
@@ -1,0 +1,6 @@
+resource "google_service_account" "previews" {
+  account_id   = "web-previews"
+  display_name = "Web previews"
+  description  = "Runtime identity of the preview origin service. It serves files baked into its own image and holds no roles."
+  project      = var.project
+}

--- a/terraform/modules/previews/main.tf
+++ b/terraform/modules/previews/main.tf
@@ -49,3 +49,12 @@ resource "google_cloud_run_v2_service" "previews" {
     ]
   }
 }
+
+resource "google_cloud_run_v2_service_iam_member" "previews" {
+  location = google_cloud_run_v2_service.previews.location
+  name     = google_cloud_run_v2_service.previews.name
+  project  = var.project
+
+  member = "allUsers"
+  role   = "roles/run.invoker"
+}

--- a/terraform/modules/previews/outputs.tf
+++ b/terraform/modules/previews/outputs.tf
@@ -1,0 +1,4 @@
+output "service_account" {
+  value       = google_service_account.previews
+  description = "Service account for the Cloud Run service."
+}

--- a/terraform/modules/previews/outputs.tf
+++ b/terraform/modules/previews/outputs.tf
@@ -1,4 +1,14 @@
+output "service" {
+  value       = google_cloud_run_v2_service.previews.name
+  description = "Cloud Run service name."
+}
+
 output "service_account" {
   value       = google_service_account.previews
   description = "Service account for the Cloud Run service."
+}
+
+output "service_url" {
+  value       = google_cloud_run_v2_service.previews.uri
+  description = "Cloud Run service URL. Tagged revisions are published at <tag>---<host> of this URL."
 }

--- a/terraform/modules/previews/readme.md
+++ b/terraform/modules/previews/readme.md
@@ -1,0 +1,8 @@
+# previews
+
+The origin previews are served from. One Cloud Run service carrying a revision
+per preview, each reachable at its own traffic tag.
+
+Terraform owns the shape of the service. CI owns what runs on it: the revisions,
+their images and their tags. Nothing here is reachable from the internet — the
+router in `../previews-router` is the only way in.

--- a/terraform/modules/previews/variables.tf
+++ b/terraform/modules/previews/variables.tf
@@ -1,3 +1,13 @@
+variable "image" {
+  type        = string
+  description = "Image the service is created with. Revisions are deployed from CI, one per preview, so this only ever serves as a placeholder until the first one lands."
+}
+
+variable "location" {
+  type        = string
+  description = "Cloud Run service location."
+}
+
 variable "project" {
   type        = string
   description = "Project ID for the project where resources are configured."

--- a/terraform/modules/previews/variables.tf
+++ b/terraform/modules/previews/variables.tf
@@ -1,0 +1,4 @@
+variable "project" {
+  type        = string
+  description = "Project ID for the project where resources are configured."
+}

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -119,6 +119,7 @@ locals {
         "dns.googleapis.com",
         "iap.googleapis.com",
         "monitoring.googleapis.com",
+        "run.googleapis.com",
       ]
 
       iam_members = {

--- a/terraform/web/previews.tf
+++ b/terraform/web/previews.tf
@@ -1,0 +1,5 @@
+module "previews" {
+  source = "../modules/previews"
+
+  project = module.project["edge"].project_id
+}

--- a/terraform/web/previews.tf
+++ b/terraform/web/previews.tf
@@ -1,5 +1,7 @@
 module "previews" {
   source = "../modules/previews"
 
-  project = module.project["edge"].project_id
+  image    = var.preview_image
+  location = local.region
+  project  = module.project["edge"].project_id
 }

--- a/terraform/web/variables.tf
+++ b/terraform/web/variables.tf
@@ -1,3 +1,9 @@
+variable "preview_image" {
+  default     = "us-docker.pkg.dev/cloudrun/container/hello"
+  description = "Image the preview origin service is created with. Revisions are deployed from CI, one per preview, so this only ever serves as a placeholder until the first one lands."
+  type        = string
+}
+
 variable "repo_name" {
   default     = "langri-sha.com"
   description = "Name of the GitHub monorepo."


### PR DESCRIPTION
First of five stacked changes that move previews from a public backend bucket to an IAP-protected router in front of per-preview Cloud Run revisions.

This one adds the origin: the service that will carry one tagged revision per preview. It is inert until something deploys a revision onto it and something else routes traffic at it, both of which come later in the stack.

## What lands

- `run.googleapis.com` on the edge project
- A runtime service account for the origin, holding no roles — it serves files baked into its own image
- The Cloud Run service, created with the `hello` placeholder and ignoring changes to its image and traffic afterwards. Terraform owns the shape; CI owns the revisions and their tags
- The invoker binding

## Why internal ingress

Every traffic tag publishes its own `run.app` URL. Anything looser would put one unauthenticated bypass on the internet per preview, which is the thing the rest of the stack exists to prevent. `allUsers` on the invoker is safe only because ingress admits nothing but the load balancer and internal traffic.

## Review notes

Terraform `fmt -check` and `validate` pass at every commit, run against the pinned 1.15.8 with the 7.43.0 provider. The only validation warning is a pre-existing `numeric_id` deprecation inside the vendored VPC module.

Nothing here is reachable from the internet and no traffic moves. The one commit in the whole stack that can move live traffic is in the third PR, and it is gated behind an IAP OAuth client that does not exist yet.