### PR TITLE
Set up the preview router on Cloud Run

### DIFF
--- a/terraform/modules/previews-router/main.tf
+++ b/terraform/modules/previews-router/main.tf
@@ -62,3 +62,12 @@ resource "google_cloud_run_v2_service" "previews_router" {
     ]
   }
 }
+
+resource "google_cloud_run_v2_service_iam_member" "previews_router" {
+  location = google_cloud_run_v2_service.previews_router.location
+  name     = google_cloud_run_v2_service.previews_router.name
+  project  = var.project
+
+  member = "allUsers"
+  role   = "roles/run.invoker"
+}

--- a/terraform/modules/previews-router/main.tf
+++ b/terraform/modules/previews-router/main.tf
@@ -1,0 +1,6 @@
+resource "google_service_account" "previews_router" {
+  account_id   = "preview-router"
+  display_name = "Preview router"
+  description  = "Runtime identity of the preview router. It proxies to the origin service and holds no roles."
+  project      = var.project
+}

--- a/terraform/modules/previews-router/main.tf
+++ b/terraform/modules/previews-router/main.tf
@@ -4,3 +4,61 @@ resource "google_service_account" "previews_router" {
   description  = "Runtime identity of the preview router. It proxies to the origin service and holds no roles."
   project      = var.project
 }
+
+resource "google_cloud_run_v2_service" "previews_router" {
+  name     = "preview-router"
+  location = var.location
+  project  = var.project
+
+  ingress             = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  deletion_protection = false
+
+  template {
+    service_account                  = google_service_account.previews_router.email
+    max_instance_request_concurrency = 80
+
+    scaling {
+      max_instance_count = 4
+      min_instance_count = 0
+    }
+
+    vpc_access {
+      egress = "ALL_TRAFFIC"
+
+      network_interfaces {
+        network    = var.network
+        subnetwork = var.subnetwork
+      }
+    }
+
+    containers {
+      image = var.image
+
+      ports {
+        container_port = 8080
+      }
+
+      env {
+        name  = "PREVIEWS_SERVICE_HOST"
+        value = var.previews_service_host
+      }
+
+      resources {
+        cpu_idle = true
+
+        limits = {
+          cpu    = "1"
+          memory = "256Mi"
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+      template[0].containers[0].image,
+    ]
+  }
+}

--- a/terraform/modules/previews-router/outputs.tf
+++ b/terraform/modules/previews-router/outputs.tf
@@ -1,0 +1,4 @@
+output "service_account" {
+  value       = google_service_account.previews_router
+  description = "Service account for the Cloud Run service."
+}

--- a/terraform/modules/previews-router/outputs.tf
+++ b/terraform/modules/previews-router/outputs.tf
@@ -1,3 +1,8 @@
+output "service" {
+  value       = google_cloud_run_v2_service.previews_router.name
+  description = "Cloud Run service name."
+}
+
 output "service_account" {
   value       = google_service_account.previews_router
   description = "Service account for the Cloud Run service."

--- a/terraform/modules/previews-router/readme.md
+++ b/terraform/modules/previews-router/readme.md
@@ -1,0 +1,10 @@
+# previews-router
+
+The front door for previews. One Cloud Run service running the nginx image in
+`apps/preview`, which maps a preview selector onto a traffic tag of the origin
+service in `../previews` and proxies to that revision.
+
+It reaches the origin over the VPC, because the origin accepts internal traffic
+only. That needs two things together: all of the router's egress routed through
+the network, and Private Google Access on the subnet it egresses from. Drop
+either half and the requests never arrive.

--- a/terraform/modules/previews-router/variables.tf
+++ b/terraform/modules/previews-router/variables.tf
@@ -1,0 +1,4 @@
+variable "project" {
+  type        = string
+  description = "Project ID for the project where resources are configured."
+}

--- a/terraform/modules/previews-router/variables.tf
+++ b/terraform/modules/previews-router/variables.tf
@@ -1,4 +1,29 @@
+variable "image" {
+  type        = string
+  description = "Image the service is created with. Revisions are deployed from CI, so this only ever serves as a placeholder until the first one lands."
+}
+
+variable "location" {
+  type        = string
+  description = "Cloud Run service location."
+}
+
+variable "network" {
+  type        = string
+  description = "Network the service egresses through to reach the origin."
+}
+
+variable "previews_service_host" {
+  type        = string
+  description = "Host of the previews service, without scheme. Tagged revisions are published at <tag>---<host>."
+}
+
 variable "project" {
   type        = string
   description = "Project ID for the project where resources are configured."
+}
+
+variable "subnetwork" {
+  type        = string
+  description = "Subnetwork the service egresses through. Requires Private Google Access."
 }

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -152,6 +152,13 @@ locals {
           subnet_name   = "gke"
           subnet_region = local.region
         },
+        {
+          description           = "Subnet for Cloud Run direct VPC egress"
+          subnet_ip             = "172.16.4.0/26"
+          subnet_name           = "cloud-run"
+          subnet_private_access = "true"
+          subnet_region         = local.region
+        },
       ]
 
       secondary_ranges = {

--- a/terraform/web/previews-router.tf
+++ b/terraform/web/previews-router.tf
@@ -1,5 +1,10 @@
 module "previews_router" {
   source = "../modules/previews-router"
 
-  project = module.project["edge"].project_id
+  image                 = var.preview_router_image
+  location              = local.region
+  network               = module.vpc["web"].network_name
+  previews_service_host = trimprefix(module.previews.service_url, "https://")
+  project               = module.project["edge"].project_id
+  subnetwork            = module.vpc["web"].subnets["${local.region}/cloud-run"].name
 }

--- a/terraform/web/previews-router.tf
+++ b/terraform/web/previews-router.tf
@@ -1,0 +1,5 @@
+module "previews_router" {
+  source = "../modules/previews-router"
+
+  project = module.project["edge"].project_id
+}

--- a/terraform/web/variables.tf
+++ b/terraform/web/variables.tf
@@ -4,6 +4,12 @@ variable "preview_image" {
   type        = string
 }
 
+variable "preview_router_image" {
+  default     = "us-docker.pkg.dev/cloudrun/container/hello"
+  description = "Image the preview router service is created with. Revisions are deployed from CI, so this only ever serves as a placeholder until the first one lands."
+  type        = string
+}
+
 variable "repo_name" {
   default     = "langri-sha.com"
   description = "Name of the GitHub monorepo."


### PR DESCRIPTION
Second of five. Stacked on #1.

Adds the router that will sit in front of the origin. Still unreachable — it joins the load balancer in #3.

## What lands

- A `cloud-run` subnet (172.16.4.0/26) with Private Google Access
- A runtime service account for the router, holding no roles
- The Cloud Run service, with Direct VPC egress and `PREVIEWS_SERVICE_HOST` derived from the origin's URI
- The invoker binding

## The subnet is load-bearing

The origin accepts internal traffic only, so the router's requests have to leave through the VPC to count as internal at the other end. Google's private-networking guide gives two halves for this: route all traffic through the VPC, *and* enable Private Google Access on the source subnet. Dropping either half fails silently — the requests just never arrive — which is why the subnet carries a comment saying so.

A dedicated subnet rather than sharing `gke`: Direct VPC egress consumes addresses from whatever subnet it is attached to.

## Review notes

The router learns the origin's hostname from Terraform rather than from a deploy-time argument, because Cloud Run publishes a tagged revision at `<tag>---<host>` and the host is the only thing the router needs to turn a selector into an upstream.

`fmt -check` and `validate` pass at every commit.