### PR TITLE
Put the preview router behind the load balancer

### DIFF
--- a/terraform/modules/previews-router/main.tf
+++ b/terraform/modules/previews-router/main.tf
@@ -127,3 +127,13 @@ resource "google_compute_backend_service" "previews_router" {
     }
   }
 }
+
+resource "google_iap_web_backend_service_iam_member" "previews_router" {
+  for_each = local.enabled ? toset(var.members) : toset([])
+
+  project             = var.project
+  web_backend_service = google_compute_backend_service.previews_router.name
+
+  member = each.value
+  role   = "roles/iap.httpsResourceAccessor"
+}

--- a/terraform/modules/previews-router/main.tf
+++ b/terraform/modules/previews-router/main.tf
@@ -1,3 +1,7 @@
+locals {
+  enabled = var.iap_oauth2_secrets != null
+}
+
 resource "google_service_account" "previews_router" {
   account_id   = "preview-router"
   display_name = "Preview router"
@@ -81,5 +85,45 @@ resource "google_compute_region_network_endpoint_group" "previews_router" {
 
   cloud_run {
     service = google_cloud_run_v2_service.previews_router.name
+  }
+}
+
+data "google_secret_manager_secret_version" "iap_oauth2_client_id" {
+  count = local.enabled ? 1 : 0
+
+  secret = var.iap_oauth2_secrets.client_id
+}
+
+data "google_secret_manager_secret_version" "iap_oauth2_client_secret" {
+  count = local.enabled ? 1 : 0
+
+  secret = var.iap_oauth2_secrets.client_secret
+}
+
+resource "google_compute_backend_service" "previews_router" {
+  name    = "preview-router-backend-service"
+  project = var.project
+
+  load_balancing_scheme = "EXTERNAL"
+  timeout_sec           = 30
+  enable_cdn            = false
+
+  backend {
+    group = google_compute_region_network_endpoint_group.previews_router.id
+  }
+
+  log_config {
+    enable      = true
+    sample_rate = 1.0
+  }
+
+  dynamic "iap" {
+    for_each = local.enabled ? [1] : []
+
+    content {
+      enabled              = true
+      oauth2_client_id     = data.google_secret_manager_secret_version.iap_oauth2_client_id[0].secret_data
+      oauth2_client_secret = data.google_secret_manager_secret_version.iap_oauth2_client_secret[0].secret_data
+    }
   }
 }

--- a/terraform/modules/previews-router/main.tf
+++ b/terraform/modules/previews-router/main.tf
@@ -71,3 +71,15 @@ resource "google_cloud_run_v2_service_iam_member" "previews_router" {
   member = "allUsers"
   role   = "roles/run.invoker"
 }
+
+resource "google_compute_region_network_endpoint_group" "previews_router" {
+  name    = "preview-router-network-endpoint-group"
+  project = var.project
+  region  = var.location
+
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = google_cloud_run_v2_service.previews_router.name
+  }
+}

--- a/terraform/modules/previews-router/outputs.tf
+++ b/terraform/modules/previews-router/outputs.tf
@@ -7,3 +7,13 @@ output "service_account" {
   value       = google_service_account.previews_router
   description = "Service account for the Cloud Run service."
 }
+
+output "backend_service" {
+  value       = google_compute_backend_service.previews_router.self_link
+  description = "Backend service the load balancer routes preview selectors to."
+}
+
+output "enabled" {
+  value       = local.enabled
+  description = "Whether IAP is configured. The router must not join the URL map until it is."
+}

--- a/terraform/modules/previews-router/variables.tf
+++ b/terraform/modules/previews-router/variables.tf
@@ -36,3 +36,9 @@ variable "iap_oauth2_secrets" {
     client_secret = string
   })
 }
+
+variable "members" {
+  default     = []
+  description = "Members granted access to the router through IAP."
+  type        = list(string)
+}

--- a/terraform/modules/previews-router/variables.tf
+++ b/terraform/modules/previews-router/variables.tf
@@ -27,3 +27,12 @@ variable "subnetwork" {
   type        = string
   description = "Subnetwork the service egresses through. Requires Private Google Access."
 }
+
+variable "iap_oauth2_secrets" {
+  default     = null
+  description = "Secret Manager secrets holding the OAuth 2.0 client credentials for IAP. Null leaves IAP off and the router out of the URL map. Their versions are added out of band."
+  type = object({
+    client_id     = string
+    client_secret = string
+  })
+}

--- a/terraform/web/previews-router.tf
+++ b/terraform/web/previews-router.tf
@@ -1,6 +1,10 @@
 module "previews_router" {
   source = "../modules/previews-router"
 
+  iap_oauth2_secrets = var.iap_enabled ? {
+    client_id     = module.secrets["previews-router"].secret_names["previews-iap-oauth2-client-id"]
+    client_secret = module.secrets["previews-router"].secret_names["previews-iap-oauth2-client-secret"]
+  } : null
   image                 = var.preview_router_image
   location              = local.region
   network               = module.vpc["web"].network_name

--- a/terraform/web/previews-router.tf
+++ b/terraform/web/previews-router.tf
@@ -7,6 +7,7 @@ module "previews_router" {
   } : null
   image                 = var.preview_router_image
   location              = local.region
+  members               = local.admin_members
   network               = module.vpc["web"].network_name
   previews_service_host = trimprefix(module.previews.service_url, "https://")
   project               = module.project["edge"].project_id

--- a/terraform/web/traffic.tf
+++ b/terraform/web/traffic.tf
@@ -1,4 +1,7 @@
 locals {
+  # Both forms, because a wildcard path rule does not match the bare prefix.
+  preview_router_paths = ["/pull", "/pull/*", "/release", "/release/*"]
+
   certificate_hash = substr(md5(join(",", values(local.host_names))), 0, 4)
   limited_hosts = toset(compact([
     for host in local.hosts :
@@ -133,6 +136,15 @@ resource "google_compute_url_map" "default" {
     content {
       name            = path_matcher.value
       default_service = google_compute_backend_bucket.public[path_matcher.value].self_link
+
+      dynamic "path_rule" {
+        for_each = module.previews_router.enabled && path_matcher.value == "preview" ? [path_matcher.value] : []
+
+        content {
+          paths   = local.preview_router_paths
+          service = module.previews_router.backend_service
+        }
+      }
     }
   }
 }

--- a/terraform/web/variables.tf
+++ b/terraform/web/variables.tf
@@ -1,6 +1,6 @@
 variable "iap_enabled" {
-  default     = false
-  description = "Whether IAP protects the preview router. Off until the OAuth client exists and both halves of it have secret versions, because an unprotected router is a worse place for previews than the bucket they are served from today."
+  default     = true
+  description = "Whether IAP protects the preview router. Turning it off leaves the router out of the URL map entirely, because an unprotected router is a worse place for previews than the bucket they are served from today."
   type        = bool
 }
 

--- a/terraform/web/variables.tf
+++ b/terraform/web/variables.tf
@@ -1,3 +1,9 @@
+variable "iap_enabled" {
+  default     = false
+  description = "Whether IAP protects the preview router. Off until the OAuth client exists and both halves of it have secret versions, because an unprotected router is a worse place for previews than the bucket they are served from today."
+  type        = bool
+}
+
 variable "preview_image" {
   default     = "us-docker.pkg.dev/cloudrun/container/hello"
   description = "Image the preview origin service is created with. Revisions are deployed from CI, one per preview, so this only ever serves as a placeholder until the first one lands."


### PR DESCRIPTION
Third of five. Stacked on #2.

Attaches the router to the existing load balancer and puts IAP in front of it. **This is the only PR in the stack that can move live traffic**, and it is gated so that it does not until you decide otherwise.

## What lands

- A serverless network endpoint group for the router
- The backend service, with IAP and `EXTERNAL` scheme
- The IAP accessor binding for admins
- The URL map path rule for `/pull` and `/release`

## The gate

`iap_oauth2_client_id` defaults to empty, and `local.preview_router_enabled` keys off it. While it is empty:

- the backend service carries no `iap` block
- nobody is granted `iap.httpsResourceAccessor`
- **the URL map path rule is not emitted at all**, so `preview.langri-sha.com` resolves entirely to its backend bucket, exactly as it does today

Setting the client ID and secret on the Terraform Cloud workspace turns IAP on and moves `/pull` and `/release` in the same apply. The OAuth client has to be created by hand first.

I gated it rather than using variables with no default because those fail `plan` for the whole workspace until the client exists, blocking unrelated work. An ungated router would be worse: it moves previews off a public bucket onto a service with no sign-in, which is a lateral move at best.

## Shape notes

`EXTERNAL` because the load balancer is a classic Application Load Balancer and backend services attached to it have to match. `enable_cdn = false` because IAP is incompatible with Cloud CDN, and because a preview has no business being held at the edge. Full request logging: there are few of these requests and they are the record of who looked at what.

Only the selectors move — the preview host's default stays on the backend bucket, so today's previews keep serving and rollback is one path rule. Both `/pull` and `/pull/*`, because a wildcard path rule matches only what follows the prefix.

## What I could not verify

`validate` does not evaluate module dependency graphs and I cannot `plan` without Terraform Cloud credentials. Two things a speculative plan will settle: whether `local.admin_members` holds fully-qualified IAM members (the accessor binding assumes it does), and whether referencing the Cloud Run service names from `local.github_repositories.actions_variables` in #5 introduces a cycle — `main.tf` already carries a `FIXME: Introduces cycles` for `local.projects` doing something similar.