### PR TITLE
Add the preview router

### DIFF
--- a/apps/preview/.dockerignore
+++ b/apps/preview/.dockerignore
@@ -1,0 +1,2 @@
+*
+!preview-router.conf.template

--- a/apps/preview/Dockerfile
+++ b/apps/preview/Dockerfile
@@ -1,0 +1,14 @@
+FROM nginx:alpine
+
+# Cloud Run injects PORT. The default keeps `docker run` and Compose working.
+ENV PORT=8080
+
+# The metadata server is DNS on Cloud Run. Compose overrides this with Docker's
+# embedded resolver; see the `resolver` directive in the template.
+ENV RESOLVER=169.254.169.254
+
+# Rendered over the stock `default.conf` so the image serves the router and
+# nothing else.
+COPY preview-router.conf.template /etc/nginx/templates/default.conf.template
+
+EXPOSE 8080

--- a/apps/preview/preview-router.conf.template
+++ b/apps/preview/preview-router.conf.template
@@ -1,0 +1,73 @@
+# Routes a preview selector to the Cloud Run revision that serves it.
+#
+# Previews are deployed as tagged revisions of one `web-previews` service:
+# `--no-traffic --tag pull-123` for a pull request, `release-v2-13-0` for a
+# release, and the untagged revision, which holds all of the traffic, for
+# `main`. Cloud Run publishes every tag at `<tag>---<service host>`, so routing
+# a preview is a hostname rewrite and nothing else.
+
+server {
+  listen ${PORT};
+
+  # `proxy_pass` to a name held in a variable is resolved per request instead
+  # of once at startup, so nginx needs a resolver of its own. On Cloud Run that
+  # is the metadata server; Compose overrides it with Docker's embedded DNS.
+  resolver ${RESOLVER} valid=10s;
+
+  # The load balancer terminates TLS, so nginx sees plain HTTP and would build
+  # `http://` out of `$scheme` when it expands a redirect. Keep them relative.
+  absolute_redirect off;
+
+  # IAP sets these on requests it has authenticated. Anything that arrives with
+  # them already set is forged, and must not survive into an upstream request
+  # or a log line.
+  proxy_set_header x-goog-iap-jwt-assertion "";
+  proxy_set_header x-goog-authenticated-user-id "";
+  proxy_set_header x-goog-authenticated-user-email "";
+
+  proxy_set_header x-forwarded-host $host;
+
+  # Cloud Run selects the service from SNI, which nginx omits by default when
+  # the upstream name comes from a variable.
+  proxy_http_version 1.1;
+  proxy_ssl_server_name on;
+
+  # /pull/<n>/… → the `pull-<n>` revision.
+  location ~ "^/pull/([1-9][0-9]{0,6})/(.*)$" {
+    set $service pull-$1---${PREVIEWS_SERVICE_HOST};
+    proxy_pass    https://$service/$2$is_args$args;
+  }
+
+  location ~ "^/pull/([1-9][0-9]{0,6})$" {
+    return 308 /pull/$1/$is_args$args;
+  }
+
+  # /release/<tag>/… → the `release-<tag>` revision. Cloud Run traffic tags are
+  # RFC 1035 labels, so the dots become hyphens, and a prerelease suffix is held
+  # to the characters that survive that.
+  location ~ "^/release/v([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9a-z][0-9a-z-]*)/(.*)$" {
+    set $service release-v$1-$2-$3-$4---${PREVIEWS_SERVICE_HOST};
+    proxy_pass    https://$service/$5$is_args$args;
+  }
+
+  location ~ "^/release/v([0-9]+)\.([0-9]+)\.([0-9]+)/(.*)$" {
+    set $service release-v$1-$2-$3---${PREVIEWS_SERVICE_HOST};
+    proxy_pass    https://$service/$4$is_args$args;
+  }
+
+  location ~ "^/release/(v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9a-z][0-9a-z-]*)?)$" {
+    return 308 /release/$1/$is_args$args;
+  }
+
+  # A selector that does not parse is a 404 rather than a fall-through to the
+  # main preview: a typo'd pull request number must not quietly serve `main`.
+  location ~ "^/(pull|release)(/|$)" {
+    return 404;
+  }
+
+  # Everything else is `main`, on the revision holding the traffic.
+  location / {
+    set $service ${PREVIEWS_SERVICE_HOST};
+    proxy_pass    https://$service$request_uri;
+  }
+}

--- a/apps/preview/readme.md
+++ b/apps/preview/readme.md
@@ -1,0 +1,87 @@
+# preview
+
+The front door for `https://preview.langri-sha.com`. An nginx image that maps a
+preview selector onto a Cloud Run traffic tag and proxies to that revision.
+
+The shape is a well-worn one: a single preview host, a small closed set of path
+selectors, and one Cloud Run service carrying a revision per preview.
+
+## Routing
+
+Previews are tagged revisions of a single `web-previews` service. Cloud Run
+publishes every tag at `<tag>---<service host>`, so the router rewrites the
+hostname and strips the selector — the origin serves the site from its own root
+and does not know it is mounted at a subpath.
+
+| Request                   | Traffic tag            | Upstream path |
+| ------------------------- | ---------------------- | ------------- |
+| `/`, `/anything`          | _(untagged)_           | `/anything`   |
+| `/pull/123/about`         | `pull-123`             | `/about`      |
+| `/release/v2.13.0/about`  | `release-v2-13-0`      | `/about`      |
+| `/release/v2.0.0-alpha/…` | `release-v2-0-0-alpha` | `/…`          |
+
+`main` is the untagged revision, which holds 100% of the service's traffic; pull
+request and release revisions are deployed with `--no-traffic` and are reachable
+only through their tag. Traffic tags are RFC 1035 labels, which is why the dots
+in a release tag become hyphens and a prerelease suffix is held to `[0-9a-z-]`.
+
+Selectors that do not parse — `/pull/abc/`, `/pull/0123/`, a pull request number
+past seven digits, `/release/2.13.0/` — answer 404. They deliberately do not
+fall through to `main`: a typo'd pull request number must not quietly serve a
+different build. `/pull/123` and `/release/v2.13.0` redirect to their trailing
+slash form.
+
+## Identity headers
+
+`x-goog-iap-jwt-assertion` and the `x-goog-authenticated-user-*` pair are
+cleared on every inbound request before anything else happens. IAP sets them on
+requests it has authenticated; a request that arrives with them already set is
+forged, and must not reach an upstream or a log line. The router does not read
+them — authorization is IAP's, and a verification bug that fails open here would
+be worse than not looking.
+
+## What this image does not do
+
+Response policy — `Cache-Control`, `X-Robots-Tag`, security headers, SPA
+fallback, `404.html` — belongs to the preview origin image. The router only
+routes.
+
+## Configuration
+
+| Variable                | Default           |                                                                                                       |
+| ----------------------- | ----------------- | ----------------------------------------------------------------------------------------------------- |
+| `PORT`                  | `8080`            | Injected by Cloud Run.                                                                                |
+| `PREVIEWS_SERVICE_HOST` | —                 | Host of the `web-previews` service, without a tag or scheme, e.g. `web-previews-abc123-ew.a.run.app`. |
+| `RESOLVER`              | `169.254.169.254` | DNS for the per-request upstream lookup. The metadata server on Cloud Run.                            |
+
+`PREVIEWS_SERVICE_HOST` has no default on purpose. If it is unset the template
+renders the placeholder verbatim and every proxied request fails, which is a
+louder failure than silently routing somewhere plausible.
+
+## Development
+
+```sh
+docker compose up --build --force-recreate preview
+```
+
+The upstream is a placeholder that does not resolve, so requests that route
+correctly fail at DNS. That is the point: the error log records the hostname the
+router constructed, which is the behaviour worth checking.
+
+```sh
+curl -i http://localhost:9001/pull/1234/foobar
+docker compose logs preview   # …pull-1234---previews.invalid could not be resolved
+```
+
+Point it at something real to serve actual bytes:
+
+```sh
+PREVIEWS_SERVICE_HOST=web-previews-abc123-ew.a.run.app \
+  docker compose up --build --force-recreate preview
+```
+
+To read the rendered config rather than infer it:
+
+```sh
+docker compose run --rm --entrypoint nginx preview -T
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,16 @@ services:
       args:
         <<: *user-args
 
+  preview:
+    build:
+      context: ./apps/preview
+    init: true
+    environment:
+      PREVIEWS_SERVICE_HOST: ${PREVIEWS_SERVICE_HOST:-previews.invalid}
+      RESOLVER: 127.0.0.11
+    ports:
+      - '9001:8080'
+
   server:
     <<: [*pnpm-svc, *google-dns]
     command: ['start', '--http', '--host=0.0.0.0', '--allowed-hosts=localhost']


### PR DESCRIPTION
Fourth of five. Stacked on #3. First PR in the stack with no Terraform in it.

The nginx image the router service runs: maps a preview selector onto a Cloud Run traffic tag and proxies to that revision.

## Routing

| Request | Traffic tag | Upstream path |
| --- | --- | --- |
| `/about` | *(untagged)* | `/about` |
| `/pull/123/about` | `pull-123` | `/about` |
| `/release/v2.13.0/about` | `release-v2-13-0` | `/about` |
| `/release/v2.0.0-alpha/…` | `release-v2-0-0-alpha` | `/…` |

Release dots become hyphens because traffic tags are RFC 1035 labels. `v2.0.0-alpha` is a real tag in this repo's history, so the prerelease form is not hypothetical.

Selectors that do not parse — `/pull/abc/`, `/pull/0123/`, a number past seven digits, `/release/2.13.0/` — answer 404 and attempt no upstream. They deliberately do not fall through to `main`: a typo'd pull request number must not quietly serve a different build.

## Verified

Against a live container, with a self-signed HTTPS echo upstream wired up through Docker network aliases:

```
GET /pull/1234/about?x=1  +  forged x-goog-iap-jwt-assertion,
                             x-goog-authenticated-user-id, -user-email
→ upstream_uri=/about?x=1
  upstream_host=pull-1234---previews.test
  x_forwarded_host=[preview.langri-sha.com]
  iap_assertion=[]  user_id=[]  user_email=[]
```

Selector stripped, query preserved, hostname rewritten, forged identity headers cleared before the upstream saw them. The Compose flow in the readme was run too.

## Two things worth a look

The `resolver` is templated. `proxy_pass` to a name held in a variable resolves per request, and `169.254.169.254` is not reachable off Cloud Run, so a hardcoded metadata address makes local development impossible.

`proxy_ssl_server_name on`, which nginx omits by default for variable upstreams — it is how Cloud Run picks the service.

## Not in scope

Response policy — `Cache-Control`, `X-Robots-Tag`, security headers, `404.html` — belongs to the preview origin image, which does not exist yet. This routes and nothing else. Until the origin image lands, this router will resolve its upstream to a service running Google's `hello` placeholder: every selector routes correctly and serves the wrong thing.