### PR TITLE
Grant Terraform the run.admin role on edge

### DIFF
--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -127,6 +127,10 @@ locals {
           "serviceAccount:${local.web_service_account_email}",
         ]
 
+        "roles/run.admin" = [
+          "serviceAccount:${local.web_service_account_email}",
+        ]
+
         "roles/serviceusage.serviceUsageConsumer" = [
           # FIXME: Introduces cycles.
           # "serviceAccount:${module.github["langri-sha.com"].service_account.email}"


### PR DESCRIPTION
The preview origin's invoker binding fails to apply with a 403 on `run.services.setIamPolicy`. The impersonated Terraform service account can create Cloud Run services, but binding their IAM policy needs `roles/run.admin` — `roles/run.developer` does not carry that permission.

Validated with `terraform fmt -check` and `terraform validate` on 1.15.8. Not applied yet.

Closes #1254