### PR TITLE
Move the IAP OAuth client secret into Secret Manager

### DIFF
--- a/terraform/modules/previews-router/main.tf
+++ b/terraform/modules/previews-router/main.tf
@@ -1,5 +1,5 @@
 locals {
-  enabled = var.iap_oauth2_client_id != ""
+  enabled = var.iap_oauth2_secrets != null
 }
 
 resource "google_service_account" "previews_router" {
@@ -88,6 +88,18 @@ resource "google_compute_region_network_endpoint_group" "previews_router" {
   }
 }
 
+data "google_secret_manager_secret_version" "iap_oauth2_client_id" {
+  count = local.enabled ? 1 : 0
+
+  secret = var.iap_oauth2_secrets.client_id
+}
+
+data "google_secret_manager_secret_version" "iap_oauth2_client_secret" {
+  count = local.enabled ? 1 : 0
+
+  secret = var.iap_oauth2_secrets.client_secret
+}
+
 resource "google_compute_backend_service" "previews_router" {
   name    = "preview-router-backend-service"
   project = var.project
@@ -110,8 +122,8 @@ resource "google_compute_backend_service" "previews_router" {
 
     content {
       enabled              = true
-      oauth2_client_id     = var.iap_oauth2_client_id
-      oauth2_client_secret = var.iap_oauth2_client_secret
+      oauth2_client_id     = data.google_secret_manager_secret_version.iap_oauth2_client_id[0].secret_data
+      oauth2_client_secret = data.google_secret_manager_secret_version.iap_oauth2_client_secret[0].secret_data
     }
   }
 }

--- a/terraform/modules/previews-router/variables.tf
+++ b/terraform/modules/previews-router/variables.tf
@@ -28,17 +28,13 @@ variable "subnetwork" {
   description = "Subnetwork the service egresses through. Requires Private Google Access."
 }
 
-variable "iap_oauth2_client_id" {
-  default     = ""
-  description = "OAuth 2.0 client ID for IAP. Empty leaves IAP off and the router out of the URL map."
-  type        = string
-}
-
-variable "iap_oauth2_client_secret" {
-  default     = ""
-  description = "OAuth 2.0 client secret for IAP."
-  sensitive   = true
-  type        = string
+variable "iap_oauth2_secrets" {
+  default     = null
+  description = "Secret Manager secrets holding the OAuth 2.0 client credentials for IAP. Null leaves IAP off and the router out of the URL map. Their versions are added out of band."
+  type = object({
+    client_id     = string
+    client_secret = string
+  })
 }
 
 variable "members" {

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -149,6 +149,17 @@ locals {
     }
   }
 
+  secrets = {
+    "previews-router" = {
+      project = module.project["edge"].project_id
+
+      secrets = [
+        "previews-iap-oauth2-client-id",
+        "previews-iap-oauth2-client-secret",
+      ]
+    }
+  }
+
   vpc = {
     web = {
       project      = module.project["edge"].project_id

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -124,6 +124,7 @@ locals {
         "iap.googleapis.com",
         "monitoring.googleapis.com",
         "run.googleapis.com",
+        "secretmanager.googleapis.com",
       ]
 
       iam_members = {

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -136,6 +136,10 @@ locals {
           "serviceAccount:${local.web_service_account_email}",
         ]
 
+        "roles/secretmanager.admin" = [
+          "serviceAccount:${local.web_service_account_email}",
+        ]
+
         "roles/serviceusage.serviceUsageConsumer" = [
           # FIXME: Introduces cycles.
           # "serviceAccount:${module.github["langri-sha.com"].service_account.email}"

--- a/terraform/web/previews-router.tf
+++ b/terraform/web/previews-router.tf
@@ -1,14 +1,16 @@
 module "previews_router" {
   source = "../modules/previews-router"
 
-  deployers                = ["serviceAccount:${module.github["langri-sha.com"].service_account.email}"]
-  iap_oauth2_client_id     = var.iap_oauth2_client_id
-  iap_oauth2_client_secret = var.iap_oauth2_client_secret
-  image                    = var.preview_router_image
-  location                 = local.region
-  members                  = local.admin_members
-  network                  = module.vpc["web"].network_name
-  previews_service_host    = trimprefix(module.previews.service_url, "https://")
-  project                  = module.project["edge"].project_id
-  subnetwork               = module.vpc["web"].subnets["${local.region}/cloud-run"].name
+  deployers = ["serviceAccount:${module.github["langri-sha.com"].service_account.email}"]
+  iap_oauth2_secrets = var.iap_enabled ? {
+    client_id     = module.secrets["previews-router"].secret_names["previews-iap-oauth2-client-id"]
+    client_secret = module.secrets["previews-router"].secret_names["previews-iap-oauth2-client-secret"]
+  } : null
+  image                 = var.preview_router_image
+  location              = local.region
+  members               = local.admin_members
+  network               = module.vpc["web"].network_name
+  previews_service_host = trimprefix(module.previews.service_url, "https://")
+  project               = module.project["edge"].project_id
+  subnetwork            = module.vpc["web"].subnets["${local.region}/cloud-run"].name
 }

--- a/terraform/web/secrets.tf
+++ b/terraform/web/secrets.tf
@@ -1,0 +1,9 @@
+module "secrets" {
+  for_each = local.secrets
+
+  source = "github.com/langri-sha/terraform-google-cloud-platform//modules/secrets?ref=v0.12.0"
+
+  project = each.value.project
+  secrets = each.value.secrets
+  topic   = each.key
+}

--- a/terraform/web/variables.tf
+++ b/terraform/web/variables.tf
@@ -1,14 +1,7 @@
-variable "iap_oauth2_client_id" {
-  default     = ""
-  description = "OAuth 2.0 client ID for IAP on the preview router. Empty leaves the router out of the URL map, because an unprotected router is a worse place for previews than the bucket they are served from today."
-  type        = string
-}
-
-variable "iap_oauth2_client_secret" {
-  default     = ""
-  description = "OAuth 2.0 client secret for IAP on the preview router."
-  sensitive   = true
-  type        = string
+variable "iap_enabled" {
+  default     = false
+  description = "Whether IAP protects the preview router. Off until the OAuth client exists and both halves of it have secret versions, because an unprotected router is a worse place for previews than the bucket they are served from today."
+  type        = bool
 }
 
 variable "preview_image" {


### PR DESCRIPTION
Stacked on #1250, after the five-PR router stack. The IAP OAuth client reached
the router as Terraform Cloud workspace variables — the client secret a live
one; both halves now live in Secret Manager and neither passes through
Terraform's inputs.

## What lands

Secrets come from the shared `terraform-google-cloud-platform//modules/secrets`,
pinned to `v0.12.0` like the `github` module already is. `local.secrets` keys
them by topic, so the next secret is a line in the map and the next component is
an entry beside `previews-router`. `secretmanager.googleapis.com` goes on the
edge project, the Terraform service account gets `roles/secretmanager.admin`,
and the router's backend service reads `previews-iap-oauth2-client-id` and
`previews-iap-oauth2-client-secret` for its `iap` block. Nothing is mounted into
a container.

## Who reads them

Only Terraform. IAP holds the credentials on the backend service itself, so no
runtime identity needs `secretAccessor` — `secret_accessors` stays empty until
something other than Terraform reads a secret, and `topic` labels each secret
with the component it belongs to. The reads sit in the router module rather than
coming back through the workspace as `read_secret_version`, so they stay next to
the `iap` block they feed.

## The gate moved

`var.iap_oauth2_client_id` is gone, and with it the gate that keyed off it.
`var.iap_enabled` replaces it: the router module takes the two secret names or
`null`, and `local.enabled` is that null check. It has to be a plain value —
anything read out of Secret Manager comes back sensitive, and both the URL map's
path rule and the IAP member binding key their `for_each` off this gate.

Behaviour is unchanged while it is off: no `iap` block, no accessor binding, no
version lookup, and the router stays out of the URL map. The lookups are gated
because a secret with no version fails `plan` for the whole workspace, which is
the breakage #1248's gate exists to avoid.

## Applied ahead of the merge

Targeted applies from this branch, so `edge-e57d` already carries the API
enablement, `roles/secretmanager.admin` on the Terraform service account, and
both secrets — empty, labeled `topic = previews-router`. State holds them while
this PR is open, so a full apply from `main` only agrees once this and the four
PRs under it land.

## The versions are yours to add

Terraform owns the secrets and never their versions, so no value reaches the
repository, a workspace variable or a plan input. Once the OAuth client exists —
a Web application client in `edge-e57d` whose only redirect URI is
`https://iap.googleapis.com/v1/oauth/clientIds/<CLIENT_ID>:handleRedirect`:

```
printf %s '<client-id>'     | gcloud secrets versions add previews-iap-oauth2-client-id     --project edge-e57d --data-file=-
printf %s '<client-secret>' | gcloud secrets versions add previews-iap-oauth2-client-secret --project edge-e57d --data-file=-
```

`printf` rather than `echo`, because a trailing newline in the payload breaks the
handshake. Then set `iap_enabled = true` on the workspace. The data sources read
`latest`, so rotating is a new version plus an apply.

`secretmanager.admin` because creating the secrets needs
`secretmanager.secrets.create` and reading the values back needs
`secretmanager.versions.access` — no narrower predefined role carries both.

## Still unverified

`fmt -recursive -check` is clean, and `validate` plus the targeted plan and
apply ran under Terraform 1.15.8. Nothing exercises the `iap` path until
`iap_enabled` goes on: whether the full resource names resolve in the version
data sources, and whether the handshake works end to end, both wait for the
first apply with it set.
