### PR TITLE
Add Secret Manager to the edge project

### DIFF
--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -120,6 +120,7 @@ locals {
         "iap.googleapis.com",
         "monitoring.googleapis.com",
         "run.googleapis.com",
+        "secretmanager.googleapis.com",
       ]
 
       iam_members = {

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -132,6 +132,10 @@ locals {
           "serviceAccount:${local.web_service_account_email}",
         ]
 
+        "roles/secretmanager.admin" = [
+          "serviceAccount:${local.web_service_account_email}",
+        ]
+
         "roles/serviceusage.serviceUsageConsumer" = [
           # FIXME: Introduces cycles.
           # "serviceAccount:${module.github["langri-sha.com"].service_account.email}"

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -145,6 +145,17 @@ locals {
     }
   }
 
+  secrets = {
+    "previews-router" = {
+      project = module.project["edge"].project_id
+
+      secrets = [
+        "previews-iap-oauth2-client-id",
+        "previews-iap-oauth2-client-secret",
+      ]
+    }
+  }
+
   vpc = {
     web = {
       project      = module.project["edge"].project_id

--- a/terraform/web/secrets.tf
+++ b/terraform/web/secrets.tf
@@ -1,0 +1,9 @@
+module "secrets" {
+  for_each = local.secrets
+
+  source = "github.com/langri-sha/terraform-google-cloud-platform//modules/secrets?ref=v0.12.0"
+
+  project = each.value.project
+  secrets = each.value.secrets
+  topic   = each.key
+}


### PR DESCRIPTION
Activates the Secret Manager API on the edge project, grants the Terraform service account the `secretmanager.admin` role it needs, and creates the Secret Manager secret resources for the preview router's IAP OAuth client (id and secret). Secret *values* are added out of band — none appear in the repo or in Terraform state.

Extracted from work that was mistakenly committed on top of #1250 (`publish-preview-router`) instead of its own branch. The fourth commit there, which wires `terraform/modules/previews-router` to read the client secret from Secret Manager, stays on that stack — it depends on IAP variables that only exist on the unmerged #1248.

Part of #1256.
