### PR TITLE
Inherit the preset allowBuilds defaults

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -73,10 +73,7 @@ const project = new Project({
     packages: ['apps/*', 'packages/*'],
     minimumReleaseAgeExclude: ['@langri-sha/*'],
     allowBuilds: {
-      '@swc/core': true,
-      esbuild: true,
       sharp: true,
-      'unrs-resolver': true,
     },
   },
   readme: {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,8 +2,8 @@
 
 allowBuilds:
   '@swc/core': true
-  esbuild: true
-  unrs-resolver: true
+  esbuild: false
+  unrs-resolver: false
   sharp: true
 packages:
   - apps/*


### PR DESCRIPTION
Follow-up to langri-sha/projen#132. `@langri-sha/projen-project@0.26.0` started
supplying `allowBuilds` defaults, so most of what this repo declared is now
redundant.

`swcrc` is enabled here, so the preset already supplies `@swc/core: true` —
the generated `pnpm-workspace.yaml` is unchanged for that entry. `esbuild` and
`unrs-resolver` flip to the preset default of `false`; both resolve their native
code through optional dependencies (`@esbuild/linux-x64`,
`@unrs/resolver-binding-linux-x64-gnu`, neither of which has any scripts), so
denying their install scripts costs nothing. `sharp` stays declared because the
preset does not supply it.

## Validation

Per the issue, a synth alone does not prove this is safe, so the worktree-local
`node_modules` were deleted and reinstalled from scratch:

- `pnpm install --frozen-lockfile` — clean, no `ERR_PNPM_IGNORED_BUILDS`, only
  `@swc/core` builds
- `pnpm exec eslint .` — exercises `unrs-resolver`
- `pnpm exec vitest run --passWithNoTests` — exercises `esbuild`
- `pnpm exec prettier --check .`, `pnpm exec tsc --build`, `pnpm exec projen`
- `pnpm build` — Next.js production build, exercises `sharp`

Directly out of band: esbuild's JS API transforms with builds denied, and
`unrs-resolver`'s `ResolverFactory` loads its binding and resolves.

## Note

`sharp: true` is inert at `sharp@0.35.3` — it has no `install`/`postinstall` and
no `gypfile`, shipping prebuilt binaries via optional deps instead, so pnpm has
no build to gate. Kept as a forward guard for the case where sharp resolves to a
platform with no prebuilt binary and falls back to a node-gyp source build.
