### PR TITLE
Deploy web previews to the preview origin

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -91,3 +91,144 @@ jobs:
             --cache-control="public, no-store" \
             --project ${{ vars.EDGE_PROJECT_ID }} \
             --recursive
+
+  preview:
+    name: Preview
+    if: vars.PREVIEW_SERVICE != ''
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: ${{ format('{0}{1}/', vars.URL, steps.selector.outputs.base-path) }}
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup PNPM
+        uses: langri-sha/github/actions/pnpm@v0.14.1
+
+      - name: Setup Google Cloud Platform
+        uses: langri-sha/github/actions/google-cloud-platform@v0.14.1
+        with:
+          service_account: ${{ vars.SERVICE_ACCOUNT }}
+          setup_gcloud: true
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Configure environment
+        id: selector
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+            echo "base-path=/pull/$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "traffic-tag=pull-$PR_NUMBER" >> $GITHUB_OUTPUT
+          elif [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            echo "base-path=/release/$TAG_NAME" >> $GITHUB_OUTPUT
+            echo "traffic-tag=release-${TAG_NAME//./-}" >> $GITHUB_OUTPUT
+          fi
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          TAG_NAME: ${{ github.event.release.tag_name }}
+
+      - name: Build
+        run: pnpm build
+        env:
+          ASSETS_URL: ${{ vars.ASSETS_URL }}
+          BASE_PATH: ${{ steps.selector.outputs.base-path }}
+
+      - name: Build image
+        run: docker build --tag preview-origin apps/web
+
+      - name: Check configuration
+        run: docker run --rm preview-origin nginx -t
+
+      - name: Check responses
+        run: |
+          docker run --detach --name origin --publish 8080:8080 preview-origin
+
+          for _ in $(seq 30); do
+            curl --silent --output /dev/null http://localhost:8080/ && break
+            sleep 1
+          done
+
+          expect() {
+            got=$(curl --silent --output /dev/null --write-out '%{http_code}' "http://localhost:8080$1")
+
+            if [ "$got" != "$2" ]; then
+              echo "::error::$1 answered $got, expected $2"
+              return 1
+            fi
+
+            echo "ok  $1 -> $got"
+          }
+
+          expect / 200
+          expect /no-such-page 404
+          expect /no-such-page/ 404
+
+          if ! curl --silent http://localhost:8080/no-such-page | grep --quiet 'could not be found'; then
+            echo "::error::the 404 answer is not the export's 404 page"
+            exit 1
+          fi
+
+          header() {
+            if ! curl --silent --head "http://localhost:8080$1" | grep --ignore-case --quiet "^$2: *$3"; then
+              echo "::error::$1 does not answer with $2: $3"
+              return 1
+            fi
+
+            echo "ok  $1 -> $2: $3"
+          }
+
+          header / cache-control 'public, no-store'
+          header / x-robots-tag noindex
+          header /no-such-page x-robots-tag noindex
+
+      - name: Publish assets
+        run: |
+          find apps/web/dist/_next -type d -empty -delete
+
+          gcloud storage cp apps/web/dist/_next/** gs://${{ vars.ASSETS_BUCKET }}/_next \
+            --cache-control="public, max-age=31536000, immutable" \
+            --no-clobber \
+            --project ${{ vars.EDGE_PROJECT_ID }} \
+            --recursive
+
+      - name: Publish image
+        run: |
+          gcloud auth configure-docker "${IMAGE%%/*}" --quiet
+
+          docker tag preview-origin "$IMAGE:$IMAGE_TAG"
+          docker push "$IMAGE:$IMAGE_TAG"
+        env:
+          IMAGE: ${{ vars.PREVIEW_IMAGE }}
+          IMAGE_TAG: ${{ steps.selector.outputs.traffic-tag || 'main' }}-${{ github.sha }}
+
+      - name: Deploy
+        run: |
+          if [ -n "$TRAFFIC_TAG" ]; then
+            gcloud run deploy ${{ vars.PREVIEW_SERVICE }} \
+              --image "$IMAGE:$IMAGE_TAG" \
+              --no-traffic \
+              --project ${{ vars.EDGE_PROJECT_ID }} \
+              --quiet \
+              --region ${{ vars.PREVIEW_REGION }} \
+              --tag "$TRAFFIC_TAG"
+          else
+            gcloud run deploy ${{ vars.PREVIEW_SERVICE }} \
+              --image "$IMAGE:$IMAGE_TAG" \
+              --project ${{ vars.EDGE_PROJECT_ID }} \
+              --quiet \
+              --region ${{ vars.PREVIEW_REGION }}
+
+            gcloud run services update-traffic ${{ vars.PREVIEW_SERVICE }} \
+              --project ${{ vars.EDGE_PROJECT_ID }} \
+              --quiet \
+              --region ${{ vars.PREVIEW_REGION }} \
+              --to-latest
+          fi
+        env:
+          IMAGE: ${{ vars.PREVIEW_IMAGE }}
+          IMAGE_TAG: ${{ steps.selector.outputs.traffic-tag || 'main' }}-${{ github.sha }}
+          TRAFFIC_TAG: ${{ steps.selector.outputs.traffic-tag }}

--- a/apps/web/.dockerignore
+++ b/apps/web/.dockerignore
@@ -1,0 +1,3 @@
+*
+!dist
+!preview-origin.conf.template

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx:alpine
+
+# Cloud Run injects PORT. The default keeps `docker run` and Compose working.
+ENV PORT=8080
+
+# Rendered over the stock `default.conf` so the image serves the site and
+# nothing else.
+COPY preview-origin.conf.template /etc/nginx/templates/default.conf.template
+
+COPY dist /usr/share/nginx/html
+
+EXPOSE 8080

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from 'next'
 
 const config: NextConfig = {
   assetPrefix: process.env.ASSETS_URL,
+  basePath: process.env.BASE_PATH,
   distDir: 'dist',
   output: 'export',
   reactStrictMode: true,

--- a/apps/web/preview-origin.conf.template
+++ b/apps/web/preview-origin.conf.template
@@ -1,0 +1,30 @@
+server {
+  listen ${PORT};
+
+  root /usr/share/nginx/html;
+
+  error_page 404 /404.html;
+
+  add_header Cache-Control "public, no-store" always;
+  add_header Referrer-Policy no-referrer always;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  add_header X-Content-Type-Options nosniff always;
+  add_header X-Frame-Options deny always;
+  add_header X-Robots-Tag noindex always;
+
+  # A location with any `add_header` of its own inherits none.
+  location /_next/ {
+    add_header Cache-Control "public, max-age=31536000, immutable" always;
+    add_header Referrer-Policy no-referrer always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options deny always;
+    add_header X-Robots-Tag noindex always;
+
+    try_files $uri =404;
+  }
+
+  location / {
+    try_files $uri $uri.html $uri/index.html =404;
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,13 @@ services:
     ports:
       - '9001:8080'
 
+  preview-origin:
+    build:
+      context: ./apps/web
+    init: true
+    ports:
+      - '9002:8080'
+
   server:
     <<: [*pnpm-svc, *google-dns]
     command: ['start', '--http', '--host=0.0.0.0', '--allowed-hosts=localhost']

--- a/terraform/modules/previews-router/main.tf
+++ b/terraform/modules/previews-router/main.tf
@@ -100,6 +100,25 @@ data "google_secret_manager_secret_version" "iap_oauth2_client_secret" {
   secret = var.iap_oauth2_secrets.client_secret
 }
 
+resource "google_project_service_identity" "iap" {
+  provider = google-beta
+  count    = local.enabled ? 1 : 0
+
+  project = var.project
+  service = "iap.googleapis.com"
+}
+
+resource "google_cloud_run_v2_service_iam_member" "previews_router_iap" {
+  count = local.enabled ? 1 : 0
+
+  location = google_cloud_run_v2_service.previews_router.location
+  name     = google_cloud_run_v2_service.previews_router.name
+  project  = var.project
+
+  member = "serviceAccount:${google_project_service_identity.iap[0].email}"
+  role   = "roles/run.invoker"
+}
+
 resource "google_compute_backend_service" "previews_router" {
   name    = "preview-router-backend-service"
   project = var.project

--- a/terraform/modules/previews/main.tf
+++ b/terraform/modules/previews/main.tf
@@ -58,3 +58,10 @@ resource "google_cloud_run_v2_service_iam_member" "previews" {
   member = "allUsers"
   role   = "roles/run.invoker"
 }
+
+resource "google_service_account_iam_binding" "previews_deployers" {
+  service_account_id = google_service_account.previews.name
+
+  members = toset(var.deployers)
+  role    = "roles/iam.serviceAccountUser"
+}

--- a/terraform/modules/previews/main.tf
+++ b/terraform/modules/previews/main.tf
@@ -45,6 +45,7 @@ resource "google_cloud_run_v2_service" "previews" {
       client,
       client_version,
       template[0].containers[0].image,
+      template[0].revision,
       traffic,
     ]
   }

--- a/terraform/modules/previews/variables.tf
+++ b/terraform/modules/previews/variables.tf
@@ -1,3 +1,9 @@
+variable "deployers" {
+  default     = []
+  description = "Members that deploy revisions of the service and act as its runtime identity."
+  type        = list(string)
+}
+
 variable "image" {
   type        = string
   description = "Image the service is created with. Revisions are deployed from CI, one per preview, so this only ever serves as a placeholder until the first one lands."

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -63,9 +63,11 @@ locals {
         for name, data in module.project :
         "${upper(name)}_PROJECT_ID" => data.project_id
         }, {
+        PREVIEW_IMAGE          = "${lower(local.location)}-docker.pkg.dev/${module.project["build"].project_id}/${google_artifact_registry_repository.repository["docker"].repository_id}/web-previews"
         PREVIEW_REGION         = local.region
         PREVIEW_ROUTER_IMAGE   = "${lower(local.location)}-docker.pkg.dev/${module.project["build"].project_id}/${google_artifact_registry_repository.repository["docker"].repository_id}/preview-router"
         PREVIEW_ROUTER_SERVICE = module.previews_router.service
+        PREVIEW_SERVICE        = module.previews.service
       })
 
       environments = {

--- a/terraform/web/previews.tf
+++ b/terraform/web/previews.tf
@@ -1,7 +1,8 @@
 module "previews" {
   source = "../modules/previews"
 
-  image    = var.preview_image
-  location = local.region
-  project  = module.project["edge"].project_id
+  deployers = ["serviceAccount:${module.github["langri-sha.com"].service_account.email}"]
+  image     = var.preview_image
+  location  = local.region
+  project   = module.project["edge"].project_id
 }


### PR DESCRIPTION
## Summary

The origin half of the preview router work: an nginx image that serves the built export, `web.yml` jobs that check, publish and deploy it, and the Terraform plumbing that was deferred until now. One revision per pull request (`pull-<n>`) and release (`release-v<X>-<Y>-<Z>`), each reachable only through its traffic tag; `main` takes the untagged revision and the traffic.

Closes #1262.

## The preview image is self-contained

The image is built for exactly one selector: the preview build sets `basePath` to `/pull/<n>` or `/release/<tag>` and no `assetPrefix`, so the export emits `/pull/<n>/_next/…`. Those URLs route back through the router, which strips the selector, and the origin serves them out of the image. A preview therefore depends on nothing but itself — no assets bucket, no cross-origin fetch, and no window where a revision is live before its assets have finished uploading.

This costs a second build per event, and the artifact split is the reason: `web` keeps the absolute assets host for the bucket deploy, `web-preview` carries the base path for the image. The export stays flat either way, so the origin still serves from its own root. Because image contents now depend on the selector, the image tag carries it too — a rebase merge can put the same commit on `main`.

## Decisions on the open questions

- **`basePath` is set per target**, not deferred. Without it the export emits root-relative `/_next/…`, which resolves against the page origin, escapes the selector entirely and falls through to the backend bucket, which does not hold `_next`. Absolute asset URLs would work but tie previews to a bucket whose CORS only admits the site's own host — which breaks release previews specifically, since a release builds against the production assets host. `basePath` also covers internal links, so a second route will not escape the selector the way `assetPrefix` alone would have let it.
- **The bucket previews stay for now.** The router path only owns `/pull/*` and `/release/*` on the preview host, so retiring the public path is a separate move: #1264.
- **Cleanup is #1263.** Closing a pull request should reap its `pull-<n>` tag and revision; release tags are deliberately permanent, which is another reason the image must be self-contained.

## Notes for review

- The `Preview` job stands down when `vars.PREVIEW_SERVICE` is unset, so it skipped until the apply exported it.
- A `--no-traffic` deploy pins the service's traffic to a named revision, which is why `main` deploys follow with `update-traffic --to-latest`.
- The release trigger is `types: [released]`, which does not fire when a prerelease is published. The router already resolves prerelease tags, so `prereleased` can be added whenever that is wanted; it predates this branch.

## Validation

- Applied. `PREVIEW_IMAGE`, `PREVIEW_SERVICE` and the `serviceAccountUser` grant landed, then the IAP service agent and its invoker grant.
- `/pull/1265/` serves this branch's build through IAP.
- The deployed digest was pulled and run: it fetches `/pull/1265/_next/…`, mentions no assets host, answers a typo with the export's own 404 page, and carries the cache and robots headers.
