### PR TITLE
Retire the public bucket previews

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -37,11 +37,12 @@ jobs:
 
   deploy:
     name: Deploy
+    if: github.event_name == 'release'
     runs-on: ubuntu-latest
     needs: [build]
     environment:
-      name: ${{ github.event_name == 'release' && 'production' || 'preview' }}
-      url: ${{ github.event_name == 'pull_request' && format('{0}/{1}', vars.URL, github.event.pull_request.number) || vars.URL }}
+      name: production
+      url: ${{ vars.URL }}
     permissions:
       contents: read
       id-token: write
@@ -65,16 +66,6 @@ jobs:
           name: web
           path: dist/web
 
-      - name: Configure environment
-        run: |
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-            echo "BUCKET=${{ vars.BUCKET }}/${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-            echo "URL=${{ vars.URL }}/${{ github.event.pull_request.number }}" >> $GITHUB_ENV
-          else
-            echo "BUCKET=${{ vars.BUCKET }}" >> $GITHUB_ENV
-            echo "URL=${{ vars.URL }}" >> $GITHUB_ENV
-          fi
-
       - name: Publish assets
         run: |
           gcloud storage cp dist/web/_next/** gs://${{ vars.ASSETS_BUCKET }}/_next \
@@ -87,7 +78,7 @@ jobs:
         run: |
           rm -rf dist/web/_next
 
-          gcloud storage cp dist/web/* gs://${{ env.BUCKET }} \
+          gcloud storage cp dist/web/* gs://${{ vars.BUCKET }} \
             --cache-control="public, no-store" \
             --project ${{ vars.EDGE_PROJECT_ID }} \
             --recursive

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -75,7 +75,6 @@ locals {
           actions_variables = {
             ASSETS_BUCKET = google_storage_bucket.public["preview-assets"].name
             ASSETS_URL    = local.host_urls["preview-assets"]
-            BUCKET        = google_storage_bucket.public["preview"].name
             URL           = local.host_urls["preview"]
           }
         }

--- a/terraform/web/traffic.tf
+++ b/terraform/web/traffic.tf
@@ -1,7 +1,4 @@
 locals {
-  # Both forms, because a wildcard path rule does not match the bare prefix.
-  preview_router_paths = ["/pull", "/pull/*", "/release", "/release/*"]
-
   certificate_hash = substr(md5(join(",", values(local.host_names))), 0, 4)
   limited_hosts = toset(compact([
     for host in local.hosts :
@@ -134,17 +131,18 @@ resource "google_compute_url_map" "default" {
     for_each = local.limited_hosts
 
     content {
-      name            = path_matcher.value
-      default_service = google_compute_backend_bucket.public[path_matcher.value].self_link
+      name = path_matcher.value
 
-      dynamic "path_rule" {
-        for_each = module.previews_router.enabled && path_matcher.value == "preview" ? [path_matcher.value] : []
-
-        content {
-          paths   = local.preview_router_paths
-          service = module.previews_router.backend_service
-        }
-      }
+      # The preview host belongs to the router whole, not by selector: it
+      # resolves `/pull/<n>/` and `/release/<tag>/` onto their tagged revisions
+      # and everything else onto the untagged one, which is `main`. Its bucket
+      # only serves the host again if IAP goes away and the router leaves the
+      # URL map with it.
+      default_service = (
+        module.previews_router.enabled && path_matcher.value == "preview"
+        ? module.previews_router.backend_service
+        : google_compute_backend_bucket.public[path_matcher.value].self_link
+      )
     }
   }
 }


### PR DESCRIPTION
## Summary

The preview host moves onto the router whole. Its default route pointed at the backend bucket, which is what kept `main` off the router and kept the public `preview.langri-sha.com/<n>` path alive; with the default service pointed at the router's backend service, `/pull/<n>/` and `/release/<tag>/` still resolve onto their tagged revisions and everything else resolves onto the untagged one, which is `main`. The per-selector `path_rule` goes with it — it only ever restated what the router already does.

`web.yml` then stops publishing HTML to that bucket at all. `Deploy` becomes the release path alone: pull requests and `main` are previewed by the `Preview` job's tagged and untagged revisions, so the `preview` environment no longer needs a `BUCKET`.

Closes #1264.

## What stays

The preview assets bucket and the `Preview` job's upload to it. Preview builds set `basePath` per selector but keep `assetPrefix` at the assets host, so an exported page fetches `_next` from `assets.preview.langri-sha.com`, whose CORS already admits the preview host. Nothing about that changes here.

The preview content bucket keeps its root objects — the last `main` build, `CNAME`, `robots.txt`, the search-console token. The stale numeric `<n>` prefixes are cleaned out separately, after the cutover is verified live, since they are the public copies this issue is about.

The backend bucket resource stays too: `iap_enabled = false` still leaves the router out of the URL map, and the host has to fall back to something.

## Validation

- `terraform fmt -check`, `validate`, and a `plan` against the workspace: `0 to add, 1 to change, 1 to destroy` — the URL map's `preview` default service, and the now-unused `preview` environment `BUCKET` variable.
- The untagged revision the host is about to default to is `web-previews-00008-pck`, ready and holding 100% of traffic, running the `main` image from the last push.
- The live cutover, the authenticated end-to-end check on both `/` and `/pull/<n>/`, and the bucket cleanup follow the apply.
