### PR TITLE
Retire the preview content bucket

### DIFF
--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -123,7 +123,6 @@ locals {
     "www"               = [local.host_urls["www"]],
     "production"        = [local.host_urls["production"]],
     "production-assets" = [local.host_urls["production"]],
-    "preview"           = [local.host_urls["preview"]],
     "preview-assets"    = [local.host_urls["preview"]],
   }
 

--- a/terraform/web/previews-router.tf
+++ b/terraform/web/previews-router.tf
@@ -2,10 +2,10 @@ module "previews_router" {
   source = "../modules/previews-router"
 
   deployers = ["serviceAccount:${module.github["langri-sha.com"].service_account.email}"]
-  iap_oauth2_secrets = var.iap_enabled ? {
+  iap_oauth2_secrets = {
     client_id     = module.secrets["previews-router"].secret_names["previews-iap-oauth2-client-id"]
     client_secret = module.secrets["previews-router"].secret_names["previews-iap-oauth2-client-secret"]
-  } : null
+  }
   image                 = var.preview_router_image
   location              = local.region
   members               = local.admin_members

--- a/terraform/web/storages.tf
+++ b/terraform/web/storages.tf
@@ -15,9 +15,7 @@ data "google_iam_policy" "public_storage_bucket" {
 }
 
 resource "google_storage_bucket" "public" {
-  for_each = toset(compact([
-    for host in local.hosts : contains(keys(local.host_redirects), host) ? "" : host
-  ]))
+  for_each = local.bucket_hosts
 
   name     = local.host_names[each.value]
   location = local.location
@@ -38,9 +36,7 @@ resource "google_storage_bucket" "public" {
 }
 
 resource "google_storage_bucket_iam_policy" "default" {
-  for_each = toset(compact([
-    for host in local.hosts : contains(keys(local.host_redirects), host) ? "" : host
-  ]))
+  for_each = local.bucket_hosts
 
   bucket      = google_storage_bucket.public[each.value].name
   policy_data = data.google_iam_policy.public_storage_bucket.policy_data

--- a/terraform/web/traffic.tf
+++ b/terraform/web/traffic.tf
@@ -4,6 +4,20 @@ locals {
     for host in local.hosts :
     contains(keys(local.host_redirects), host) ? "" : host
   ]))
+
+  # Every host is served from its own bucket, except the preview host, which
+  # the router serves whole.
+  bucket_hosts = setsubtract(local.limited_hosts, ["preview"])
+
+  host_backends = merge(
+    {
+      for host in local.bucket_hosts :
+      host => google_compute_backend_bucket.public[host].self_link
+    },
+    {
+      "preview" = module.previews_router.backend_service
+    }
+  )
 }
 
 resource "google_compute_global_address" "default" {
@@ -44,7 +58,7 @@ resource "google_compute_managed_ssl_certificate" "default" {
 }
 
 resource "google_compute_backend_bucket" "public" {
-  for_each = local.limited_hosts
+  for_each = local.bucket_hosts
 
   name    = "${each.value}-backend-bucket"
   project = module.project["edge"].project_id
@@ -131,18 +145,8 @@ resource "google_compute_url_map" "default" {
     for_each = local.limited_hosts
 
     content {
-      name = path_matcher.value
-
-      # The preview host belongs to the router whole, not by selector: it
-      # resolves `/pull/<n>/` and `/release/<tag>/` onto their tagged revisions
-      # and everything else onto the untagged one, which is `main`. Its bucket
-      # only serves the host again if IAP goes away and the router leaves the
-      # URL map with it.
-      default_service = (
-        module.previews_router.enabled && path_matcher.value == "preview"
-        ? module.previews_router.backend_service
-        : google_compute_backend_bucket.public[path_matcher.value].self_link
-      )
+      name            = path_matcher.value
+      default_service = local.host_backends[path_matcher.value]
     }
   }
 }

--- a/terraform/web/variables.tf
+++ b/terraform/web/variables.tf
@@ -1,9 +1,3 @@
-variable "iap_enabled" {
-  default     = true
-  description = "Whether IAP protects the preview router. Turning it off leaves the router out of the URL map entirely, because an unprotected router is a worse place for previews than the bucket they are served from today."
-  type        = bool
-}
-
 variable "preview_image" {
   default     = "us-docker.pkg.dev/cloudrun/container/hello"
   description = "Image the preview origin service is created with. Revisions are deployed from CI, one per preview, so this only ever serves as a placeholder until the first one lands."


### PR DESCRIPTION
## Summary

The bucket behind `preview.langri-sha.com` has served nothing since #1264 moved the host onto the router. `web.yml` publishes to a bucket on releases only, and the URL map's last reference to it was the `iap_enabled = false` fallback — which stopped being a fallback when the bucket was emptied, since flipping it off now takes previews down rather than making them public.

So both go: IAP becomes unconditional on the router, and the preview host loses its bucket, that bucket's IAM policy and its backend bucket. The `preview` host entry stays — DNS record, certificate SAN, host rule, the `URL` Actions variable and the assets bucket's CORS origin all key off `local.hosts`, and none of them touch storage. The preview assets bucket is untouched.

Closes #1269.

## Notes for review

- `local.host_backends` replaces the conditional that used to pick a backend per host. A map reads better than a ternary here, and it sidesteps indexing `google_compute_backend_bucket.public["preview"]`, which no longer exists.
- `storages.tf` had the `limited_hosts` expression inlined twice; both now use `local.bucket_hosts`, which is that set minus the preview host.
- The router module keeps its `iap_oauth2_secrets = null` path and its `enabled` output. Nothing in `terraform/web` passes null anymore, but removing the module's `count` guards would rewrite resource addresses for the IAP service identity and its invoker grant, which is not worth it for dead-code tidiness.
- Destroying the bucket takes the four files left in it — `CNAME`, `google17a76c1d58d67a30.html`, `keybase.txt`, `robots.txt`. All four are in `apps/web/share/`, and none have been served on the preview host since the cutover.

## Validation

- `terraform fmt -check`, `validate`, and a `plan` against the workspace: `0 to add, 0 to change, 3 to destroy` — the bucket, its IAM policy and its backend bucket. The URL map is untouched, because `local.host_backends["preview"]` resolves to the backend service it already points at.
- The bucket needs emptying before the destroy can succeed; that happens with the apply, and the preview host gets rechecked through IAP after it.
