### PR TITLE
Order the landing content instead of layering it with z-index

### DIFF
--- a/apps/web/src/app/lib/header/index.tsx
+++ b/apps/web/src/app/lib/header/index.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import * as React from 'react'
 
-import { animations, colors, layers, media } from '@/styles'
+import { animations, colors, media } from '@/styles'
 
 import { Docker, Github, Keybase, Npm, Stackoverflow } from './icons'
 import { Wordmark } from './wordmark'
@@ -56,7 +56,6 @@ export const Header: React.FC = () => (
 
 const Root = styled.header`
   ${animations.booming};
-  ${layers.foreground};
   position: relative;
 `
 

--- a/apps/web/src/app/lib/landing.tsx
+++ b/apps/web/src/app/lib/landing.tsx
@@ -18,8 +18,10 @@ export const Landing: React.FC = () => {
       <Global styles={[global, gradientProperties]} />
       <Root>
         <Root>
-          <Header />
+          {/* The scene paints first so the header, which follows it in the
+              flow, sits on top without an isolating z-index. */}
           {process.env.EXPERIMENTAL_SCENE ? <Scene /> : null}
+          <Header />
           {playing ? <Drone /> : null}
           <Play
             playing={playing}

--- a/apps/web/src/components/play.tsx
+++ b/apps/web/src/components/play.tsx
@@ -3,7 +3,7 @@
 import styled from '@emotion/styled'
 import * as React from 'react'
 
-import { animations, colors, layers, media } from '@/styles'
+import { animations, colors, media } from '@/styles'
 
 export interface PlayProps {
   playing: boolean
@@ -22,7 +22,6 @@ export const Play: React.FC<PlayProps> = ({ playing, onToggle }) => (
 
 const Root = styled.button`
   ${animations.booming};
-  ${layers.foreground};
   position: fixed;
   right: 2rem;
   bottom: 2rem;

--- a/apps/web/src/styles/index.ts
+++ b/apps/web/src/styles/index.ts
@@ -1,5 +1,4 @@
 export { default as global } from './global'
 export * as animations from './animations'
 export * as colors from './colors'
-export * as layers from './layers'
 export * as media from './media'

--- a/apps/web/src/styles/layers.ts
+++ b/apps/web/src/styles/layers.ts
@@ -1,9 +1,0 @@
-import { type SerializedStyles, css } from '@emotion/react'
-
-export const background: SerializedStyles = css`
-  z-index: 1;
-`
-
-export const foreground: SerializedStyles = css`
-  z-index: 2;
-`


### PR DESCRIPTION
The header only sat above the scene because of a z-index. Rendering the scene first gives the same stacking from document order, so the `layers` helper — and the last z-index in the app — goes away.