### PR TITLE
Serve PostHog EU through a first-party proxy at /psthg/

### DIFF
--- a/.github/workflows/posthog-proxy.yml
+++ b/.github/workflows/posthog-proxy.yml
@@ -1,0 +1,231 @@
+name: PostHog proxy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/posthog-proxy.yml'
+      - 'apps/posthog/**'
+  pull_request:
+    paths:
+      - '.github/workflows/posthog-proxy.yml'
+      - 'apps/posthog/**'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Build image
+        run: docker build --tag posthog-proxy apps/posthog
+
+      - name: Check configuration
+        run: docker run --rm posthog-proxy nginx -t
+
+      - name: Start upstream
+        run: |
+          openssl req -x509 -newkey rsa:2048 -nodes -days 1 \
+            -subj /CN=upstream \
+            -addext "subjectAltName=DNS:assets,DNS:ingestion" \
+            -addext "basicConstraints=critical,CA:TRUE" \
+            -keyout upstream.key -out upstream.crt
+
+          docker run --rm posthog-proxy cat /etc/ssl/certs/ca-certificates.crt > ca-bundle.crt
+          cat upstream.crt >> ca-bundle.crt
+
+          cat > upstream.conf <<'CONF'
+          server {
+            listen 443 ssl;
+
+            ssl_certificate     /etc/nginx/upstream.crt;
+            ssl_certificate_key /etc/nginx/upstream.key;
+
+            location / {
+              add_header cache-control "public, max-age=14400" always;
+              add_header set-cookie "upstream=1" always;
+
+              return 200 "$request_method $request_uri host=$host cookie=$http_cookie\n";
+            }
+          }
+          CONF
+
+          docker network create posthog
+
+          docker run --detach --name upstream --network posthog \
+            --network-alias assets \
+            --network-alias ingestion \
+            --volume "$PWD/upstream.conf:/etc/nginx/conf.d/default.conf:ro" \
+            --volume "$PWD/upstream.crt:/etc/nginx/upstream.crt:ro" \
+            --volume "$PWD/upstream.key:/etc/nginx/upstream.key:ro" \
+            nginx:alpine
+
+      - name: Check upstream TLS is verified
+        run: |
+          docker run --detach --name untrusted --network posthog --publish 8081:8080 \
+            --env POSTHOG_ASSETS_HOST=assets \
+            --env POSTHOG_INGESTION_HOST=ingestion \
+            --env RESOLVER=127.0.0.11 \
+            posthog-proxy
+
+          for _ in $(seq 30); do
+            curl --silent --output /dev/null http://localhost:8081/ && break
+            sleep 1
+          done
+
+          got=$(curl --silent --output /dev/null --write-out '%{http_code}' http://localhost:8081/psthg/static/array.js)
+
+          if [ "$got" != "502" ]; then
+            echo "::error::an upstream with an untrusted certificate answered $got, expected 502"
+            exit 1
+          fi
+
+          echo "ok  untrusted upstream certificate -> $got"
+
+      - name: Check routing
+        run: |
+          docker run --detach --name proxy --network posthog --publish 8080:8080 \
+            --env POSTHOG_ASSETS_HOST=assets \
+            --env POSTHOG_INGESTION_HOST=ingestion \
+            --env RESOLVER=127.0.0.11 \
+            --volume "$PWD/ca-bundle.crt:/etc/ssl/certs/ca-certificates.crt:ro" \
+            posthog-proxy
+
+          for _ in $(seq 30); do
+            curl --silent --output /dev/null http://localhost:8080/ && break
+            sleep 1
+          done
+
+          expect() {
+            got=$(curl --silent --output /dev/null --path-as-is --write-out '%{http_code}' "http://localhost:8080$1")
+
+            if [ "$got" != "$2" ]; then
+              echo "::error::$1 answered $got, expected $2"
+              return 1
+            fi
+
+            echo "ok  $1 -> $got"
+          }
+
+          expect /psthg 308
+          expect / 404
+          expect /psthg/../array/phc_test/config.js 404
+
+          proxied() {
+            got=$(curl --silent --header 'cookie: session=secret' "http://localhost:8080$1")
+
+            if [ "$got" != "$2" ]; then
+              echo "::error::$1 reached the upstream as '$got', expected '$2'"
+              return 1
+            fi
+
+            echo "ok  $1 -> $got"
+          }
+
+          proxied '/psthg/static/recorder.js?v=1' 'GET /static/recorder.js?v=1 host=assets cookie='
+          proxied '/psthg/array/phc_test/config.js' 'GET /array/phc_test/config.js host=assets cookie='
+          proxied '/psthg/i/v0/e/?compression=gzip-js' 'GET /i/v0/e/?compression=gzip-js host=ingestion cookie='
+          proxied '/psthg/flags/?v=2' 'GET /flags/?v=2 host=ingestion cookie='
+
+          header() {
+            if ! curl --silent --head "http://localhost:8080$1" | grep --ignore-case --quiet "^$2: *$3"; then
+              echo "::error::$1 does not answer with $2: $3"
+              return 1
+            fi
+
+            echo "ok  $1 -> $2: $3"
+          }
+
+          header /psthg/static/array.js cache-control 'public, max-age=14400'
+          header /psthg/static/array.js x-content-type-options nosniff
+          header /psthg/i/v0/e/ cache-control no-store
+          header /psthg/i/v0/e/ x-content-type-options nosniff
+
+          absent() {
+            if curl --silent --head "http://localhost:8080$1" | grep --ignore-case --quiet "^$2:"; then
+              echo "::error::$1 answers with $2, which the upstream must not be able to set"
+              return 1
+            fi
+
+            echo "ok  $1 -> no $2"
+          }
+
+          absent /psthg/static/array.js set-cookie
+          absent /psthg/i/v0/e/ set-cookie
+
+          if docker logs proxy 2>&1 | grep --quiet 'compression=gzip-js'; then
+            echo "::error::the access log records query strings, which carry event data"
+            exit 1
+          fi
+
+          echo "ok  the access log records no query strings"
+
+      - name: Check a failing upstream logs no query string
+        run: |
+          docker run --detach --name failing --network posthog --publish 8082:8080 \
+            --env POSTHOG_INGESTION_HOST=nowhere.invalid \
+            --env RESOLVER=127.0.0.11 \
+            posthog-proxy
+
+          for _ in $(seq 30); do
+            curl --silent --output /dev/null http://localhost:8082/ && break
+            sleep 1
+          done
+
+          curl --silent --output /dev/null "http://localhost:8082/psthg/i/v0/e/?data=not-in-any-log"
+
+          if docker logs failing 2>&1 | grep --quiet 'not-in-any-log'; then
+            echo "::error::a failing upstream logged the query string"
+            docker logs failing 2>&1 | grep 'not-in-any-log'
+            exit 1
+          fi
+
+          echo "ok  a failing upstream logs no query string"
+
+          if ! docker logs failing 2>&1 | grep --quiet 'GET /psthg/i/v0/e/ 502'; then
+            echo "::error::the failure is not visible in the access log either"
+            exit 1
+          fi
+
+          echo "ok  the failure is still visible as a 502"
+
+  publish:
+    name: Publish
+    if: github.event_name == 'push' && vars.POSTHOG_PROXY_SERVICE != ''
+    runs-on: ubuntu-latest
+    needs: [build]
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Google Cloud Platform
+        uses: langri-sha/github/actions/google-cloud-platform@v0.14.1
+        with:
+          service_account: ${{ vars.SERVICE_ACCOUNT }}
+          setup_gcloud: true
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: Publish image
+        run: |
+          gcloud auth configure-docker "${IMAGE%%/*}" --quiet
+
+          docker build --tag "$IMAGE:$GITHUB_SHA" apps/posthog
+          docker push "$IMAGE:$GITHUB_SHA"
+        env:
+          IMAGE: ${{ vars.POSTHOG_PROXY_IMAGE }}
+
+      - name: Deploy
+        run: |
+          gcloud run services update ${{ vars.POSTHOG_PROXY_SERVICE }} \
+            --image "${{ vars.POSTHOG_PROXY_IMAGE }}:$GITHUB_SHA" \
+            --project ${{ vars.EDGE_PROJECT_ID }} \
+            --quiet \
+            --region ${{ vars.POSTHOG_PROXY_REGION }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -36,3 +36,6 @@ jobs:
         with:
           fail-on-unresolved-version: true
           working-directory: ${{ matrix.working-directory }}
+
+      - name: Run tests
+        run: terraform test

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -27,6 +27,7 @@ jobs:
         run: pnpm build
         env:
           ASSETS_URL: ${{ vars.ASSETS_URL }}
+          NEXT_PUBLIC_POSTHOG_KEY: ${{ vars.NEXT_PUBLIC_POSTHOG_KEY }}
 
       - name: Create artifact
         uses: actions/upload-artifact@v7

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -70,6 +70,7 @@ const project = new Project({
     packages: ['apps/*', 'packages/*'],
     minimumReleaseAgeExclude: ['@langri-sha/*'],
     allowBuilds: {
+      'core-js': false,
       sharp: true,
     },
   },

--- a/apps/posthog/Dockerfile
+++ b/apps/posthog/Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx:alpine
+
+ENV PORT=8080
+
+ENV RESOLVER=169.254.169.254
+
+ENV POSTHOG_ASSETS_HOST=eu-assets.i.posthog.com
+ENV POSTHOG_INGESTION_HOST=eu.i.posthog.com
+
+COPY posthog-proxy.conf.template /etc/nginx/templates/default.conf.template
+
+EXPOSE 8080

--- a/apps/posthog/posthog-proxy.conf.template
+++ b/apps/posthog/posthog-proxy.conf.template
@@ -1,0 +1,83 @@
+# Serves PostHog EU Cloud from the site's own origin at `/psthg/`. The site is a
+# static export on Cloud Storage, so there is no Next.js runtime to hold the
+# `rewrites()` rule PostHog documents; this is that rule.
+
+# `$request` and `$args` carry the query string, and an analytics request's
+# query string carries event data.
+log_format psthg '$request_method $uri $status $body_bytes_sent $request_time';
+
+server {
+  listen ${PORT};
+
+  access_log /var/log/nginx/access.log psthg;
+
+  # The error log has no format of its own, and its `request:` field carries the
+  # query string the access log above is careful to leave out. Everything it
+  # reports about an upstream failure is an `[error]`; the status codes are in
+  # the access log either way.
+  error_log /var/log/nginx/error.log crit;
+
+  # `proxy_pass` to a name held in a variable is resolved per request instead of
+  # once at startup, so nginx needs a resolver of its own. On Cloud Run that is
+  # the metadata server; Compose overrides it with Docker's embedded DNS. The
+  # upstreams are behind a CDN, so an address resolved once would outlive the
+  # host it was resolved for.
+  resolver ${RESOLVER} valid=10s;
+
+  # The load balancer terminates TLS, so nginx sees plain HTTP and would build
+  # `http://` out of `$scheme` when it expands a redirect. Keep them relative.
+  absolute_redirect off;
+
+  # A batch of events is bigger than the 1m default often enough that the 413
+  # would be a mystery.
+  client_max_body_size 10m;
+
+  # The upstreams select a certificate from SNI, which nginx omits when the
+  # upstream name comes from a variable. `Host` and the certificate name both
+  # follow the name in `proxy_pass`.
+  proxy_http_version 1.1;
+  proxy_ssl_server_name on;
+
+  # nginx does not verify an upstream certificate unless told to. Whoever holds
+  # this connection serves JavaScript that runs on our own origin, so an
+  # unauthenticated one is an open door. `proxy_ssl_name` follows `$proxy_host`,
+  # so the name checked is the name in `proxy_pass`.
+  proxy_ssl_verify              on;
+  proxy_ssl_verify_depth        2;
+  proxy_ssl_trusted_certificate /etc/ssl/certs/ca-certificates.crt;
+
+  location = /psthg {
+    return 308 /psthg/$is_args$args;
+  }
+
+  # A location with any `add_header`, `proxy_hide_header` or `proxy_set_header`
+  # of its own inherits none, so each of the two below carries the whole set.
+
+  location ~ "^/psthg/((?:array|static)/.*)$" {
+    set $upstream ${POSTHOG_ASSETS_HOST};
+    proxy_pass    https://$upstream/$1$is_args$args;
+
+    proxy_set_header  cookie "";
+    proxy_hide_header set-cookie;
+
+    add_header x-content-type-options nosniff always;
+  }
+
+  location ~ "^/psthg/(.*)$" {
+    set $upstream ${POSTHOG_INGESTION_HOST};
+    proxy_pass    https://$upstream/$1$is_args$args;
+
+    proxy_set_header  cookie "";
+    proxy_hide_header cache-control;
+    proxy_hide_header set-cookie;
+
+    add_header cache-control no-store always;
+    add_header x-content-type-options nosniff always;
+  }
+
+  # The URL map sends `/psthg` and `/psthg/*` here and nothing else. A request
+  # that arrives by some other route must not find an open proxy.
+  location / {
+    return 404;
+  }
+}

--- a/apps/posthog/readme.md
+++ b/apps/posthog/readme.md
@@ -1,0 +1,126 @@
+# posthog
+
+Serves PostHog EU Cloud from `https://langri-sha.com/psthg/`. An nginx image
+that strips the prefix and forwards to the PostHog origin that answers for the
+path, so analytics are first-party requests to our own domain instead of
+third-party requests to `posthog.com`.
+
+The site is a static export on Cloud Storage, so there is no Next.js runtime to
+hold the `rewrites()` rule PostHog documents. This is that rule, as a Cloud Run
+service on the same load balancer, reached through the `/psthg` path rules of
+the production and preview hosts and nothing else.
+
+## Routing
+
+| Request                | Upstream                                        |
+| ---------------------- | ----------------------------------------------- |
+| `/psthg/static/:path*` | `https://eu-assets.i.posthog.com/static/:path*` |
+| `/psthg/array/:path*`  | `https://eu-assets.i.posthog.com/array/:path*`  |
+| `/psthg/:path*`        | `https://eu.i.posthog.com/:path*`               |
+
+`/static/` carries the SDK bundles and `/array/` the remote configuration, both
+from the assets origin; event capture, feature flags and the rest of the API are
+answered by the ingestion origin. Methods, request bodies, query strings and
+status codes pass through untouched, and `Host` follows the upstream, which is
+how PostHog tells the two apart.
+
+`/psthg` redirects to `/psthg/`, because the load balancer routes the bare path
+here rather than leaving it on a backend bucket. Anything outside the prefix is
+a 404: the URL map sends nothing else here, and a request that arrives by some
+other route must not find an open proxy.
+
+The US origins, `us.i.posthog.com` and `us-assets.i.posthog.com`, are what
+PostHog's documentation shows by default. They appear nowhere in this image, and
+there is no fallback that could reach them.
+
+Upstream certificates are verified against the image's trust store, which nginx
+does not do on its own. What comes back is JavaScript that runs on the site's
+own origin, so an upstream the proxy cannot authenticate answers 502 rather than
+being trusted anyway. CI proves it both ways: a stub whose certificate is in the
+trust store is proxied, and the same stub without it is refused.
+
+## What does not pass through
+
+- **Cookies.** Being same-origin, the browser attaches the site's cookies to
+  every analytics request. PostHog identifies events from the request payload,
+  so they are stripped on the way out, and `Set-Cookie` is dropped on the way
+  back.
+- **Caching of API responses.** Ingestion, feature flag and API responses are
+  answered `Cache-Control: no-store`. Cloud CDN is off on the backend service,
+  so nothing is cached at the edge either. The assets keep the caching PostHog
+  advertises for them.
+- **Query strings, into the log.** A capture request carries event data in its
+  query string, and the visitor's address in `X-Forwarded-For`. The access log
+  records the method, the path, the status and the size, and none of the rest.
+  The error log has no format of its own and names the whole request line, so it
+  is held to `crit`: an upstream failure shows up as a 502 in the access log
+  instead.
+
+Nothing here rewrites CORS headers, unlike the configurations PostHog documents:
+those proxies sit on a subdomain of their own, and this one is same-origin with
+the site.
+
+## Configuration
+
+| Variable                 | Default                   |                                                                            |
+| ------------------------ | ------------------------- | -------------------------------------------------------------------------- |
+| `PORT`                   | `8080`                    | Injected by Cloud Run.                                                     |
+| `POSTHOG_ASSETS_HOST`    | `eu-assets.i.posthog.com` | Origin for the SDK bundles and remote config.                              |
+| `POSTHOG_INGESTION_HOST` | `eu.i.posthog.com`        | Origin for capture, feature flags and the API.                             |
+| `RESOLVER`               | `169.254.169.254`         | DNS for the per-request upstream lookup. The metadata server on Cloud Run. |
+
+No PostHog credentials are involved. The project token is public by design and
+lives in the browser bundle; the proxy is an unauthenticated pass-through and
+holds nothing of its own.
+
+## Development
+
+```sh
+docker compose up --build --force-recreate posthog
+curl -i http://localhost:9003/psthg/static/array.js
+```
+
+The upstreams are the real ones, so this serves the actual SDK. To read the
+rendered config rather than infer it:
+
+```sh
+docker compose run --rm --entrypoint nginx posthog -T
+```
+
+## Deploying
+
+The pieces come up in this order, and the order matters: the site must not start
+sending events before there is a revision to answer them.
+
+1. `terraform apply` in `terraform/web` creates the Cloud Run service, the
+   serverless network endpoint group, the backend service and the `/psthg` path
+   rules on the production and preview hosts. The service is created with
+   Google's `hello` placeholder image, so `/psthg/*` answers, with nothing
+   useful.
+2. A push to `main` publishes the image and deploys the first real revision.
+   From there `/psthg/static/array.js` serves the SDK and `/psthg/i/v0/e/`
+   accepts events.
+3. The apply also creates the `posthog-project-token` secret, empty. Add the
+   project token from PostHog EU — the `phc_` value in its project settings, not
+   the `phx_` personal API key — as a version:
+
+   ```sh
+   gcloud secrets versions add posthog-project-token --data-file=-
+   ```
+
+   The next apply reads it into `NEXT_PUBLIC_POSTHOG_KEY` on the production
+   environment, and the release after that builds with analytics on. Rotating
+   the token is a new version and an apply, never a commit. Until a version
+   exists the variable is empty and the site builds without analytics, which is
+   also what every preview build does.
+
+The service takes `INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER`, so the `run.app` URL
+Cloud Run assigns it answers nothing. That it stays that way is worth checking
+after a deploy:
+
+```sh
+curl -i "$(gcloud run services describe posthog-proxy --format='value(status.url)')/psthg/static/array.js"
+curl -i https://langri-sha.com/psthg/static/array.js
+```
+
+The first must fail to connect or answer 404; the second must serve the SDK.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,8 @@
     "@emotion/react": "11.14.0",
     "@emotion/styled": "11.14.1",
     "next": "16.3.2",
-    "normalize.css": "8.0.1"
+    "normalize.css": "8.0.1",
+    "posthog-js": "1.417.1"
   },
   "devDependencies": {
     "@langri-sha/babel-preset": "^0.6.3",

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { Metadata, Viewport } from 'next'
 import Script from 'next/script'
 
+import { Analytics } from './lib/analytics'
 import { EmotionRegistry } from './lib/emotion-registry'
 
 export const metadata: Metadata = {
@@ -40,6 +41,7 @@ export default function RootLayout({
         />
       </head>
       <body>
+        <Analytics />
         <EmotionRegistry>{children}</EmotionRegistry>
       </body>
     </html>

--- a/apps/web/src/app/lib/analytics/index.tsx
+++ b/apps/web/src/app/lib/analytics/index.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import * as React from 'react'
+
+import { options } from './options'
+
+/*
+ * Initializes PostHog against the first-party proxy at `/psthg`, which forwards
+ * to PostHog EU Cloud. Same-origin requests keep analytics working for visitors
+ * whose blockers drop `posthog.com`, and keep their addresses off a third-party
+ * domain.
+ *
+ * The project API key is public by design, and is built into production bundles
+ * only. Importing the SDK behind it keeps a build without one — a preview, or
+ * anything built locally — from loading it at all.
+ *
+ * @see https://posthog.com/docs/advanced/proxy
+ */
+export const Analytics: React.FC = () => {
+  React.useEffect(() => {
+    const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
+
+    if (!key) {
+      return
+    }
+
+    void import('posthog-js').then(({ posthog }) => {
+      posthog.init(key, options)
+    })
+  }, [])
+
+  return null
+}

--- a/apps/web/src/app/lib/analytics/options.test.ts
+++ b/apps/web/src/app/lib/analytics/options.test.ts
@@ -1,0 +1,24 @@
+import { expect, test } from 'vitest'
+
+import { options } from './options'
+
+test('analytics are sent to the first-party path', () => {
+  expect(options.api_host).toBe('/psthg')
+})
+
+test('no option reaches for a PostHog host outside the EU', () => {
+  const hosts = Object.values(options).filter(
+    (value) => typeof value === 'string' && value.includes('posthog.com'),
+  )
+
+  expect(hosts).toEqual(['https://eu.posthog.com'])
+})
+
+test('broad and sensitive capture is off', () => {
+  expect(options.autocapture).toBe(false)
+  expect(options.capture_exceptions).toBe(false)
+  expect(options.capture_heatmaps).toBe(false)
+  expect(options.disable_session_recording).toBe(true)
+  expect(options.person_profiles).toBe('identified_only')
+  expect(options.respect_dnt).toBe(true)
+})

--- a/apps/web/src/app/lib/analytics/options.ts
+++ b/apps/web/src/app/lib/analytics/options.ts
@@ -1,0 +1,16 @@
+import type { PostHogConfig } from 'posthog-js'
+
+export const options: Partial<PostHogConfig> = {
+  api_host: '/psthg',
+
+  ui_host: 'https://eu.posthog.com',
+
+  defaults: '2026-06-25',
+
+  autocapture: false,
+  capture_exceptions: false,
+  capture_heatmaps: false,
+  disable_session_recording: true,
+  person_profiles: 'identified_only',
+  respect_dnt: true,
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,15 @@ services:
       args:
         <<: *user-args
 
+  posthog:
+    build:
+      context: ./apps/posthog
+    init: true
+    environment:
+      RESOLVER: 127.0.0.11
+    ports:
+      - '9003:8080'
+
   preview:
     build:
       context: ./apps/preview

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       normalize.css:
         specifier: 8.0.1
         version: 8.0.1
+      posthog-js:
+        specifier: 1.417.1
+        version: 1.417.1
       react:
         specifier: ^19.0.0
         version: 19.2.8
@@ -1910,6 +1913,15 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  '@posthog/browser-common@0.5.2':
+    resolution: {integrity: sha512-8GvfEshFdeKIccuy3kpp6mDBxawQtRamMYRCwzy1r1ixLKQVLAGs3afhOf6r75yp59ZQBi5mtXQgUJ2Jz8eHuw==}
+
+  '@posthog/core@1.48.11':
+    resolution: {integrity: sha512-fvKbxGaUM8RuCDB1jdhSqAHYjk42INfJDWT1KVezn74sCrfnr1YaUafxzmcS+87D5FzbA2tu7IT0GQRV2WkkRg==}
+
+  '@posthog/types@1.406.2':
+    resolution: {integrity: sha512-RNNoKD7+ZD2v5uzIDp1SOKK1CseZ+YgNPRYCoPlVKuu+wTB/Tb41JCprMjX9E24gPcsdDg8B47dsEsmO0nwEfw==}
+
   '@rolldown/binding-android-arm-eabi@1.2.5':
     resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2225,6 +2237,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -2833,6 +2848,9 @@ packages:
     resolution: {integrity: sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==}
     engines: {node: '>=6.4.0'}
 
+  core-js@3.50.0:
+    resolution: {integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==}
+
   cosmiconfig@7.1.0:
     resolution: {integrity: sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==}
     engines: {node: '>=10'}
@@ -2916,6 +2934,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.4.14:
+    resolution: {integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3208,6 +3229,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.4.9:
+    resolution: {integrity: sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -4380,6 +4404,17 @@ packages:
     resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  posthog-js@1.417.1:
+    resolution: {integrity: sha512-QpZnHA2PieGq9+W03LBw23DnN9CD1zM37DcXnpZkg+C5iAwYXLiZs8qof0Yi/BhY35PYuhVmv93nhztyHjVaJw==}
+
+  preact@10.29.8:
+    resolution: {integrity: sha512-ej2aVZ+vZ8WO7tvlQWRM9N63A0KzF9q4mWJfDUHgYaIofWY9hu74QdnQrjoPMmZi2/nZ5gN0bJCQF49xQqx09Q==}
+    peerDependencies:
+      preact-render-to-string: '>=5'
+    peerDependenciesMeta:
+      preact-render-to-string:
+        optional: true
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4441,6 +4476,9 @@ packages:
 
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
+
+  query-selector-shadow-dom@1.0.1:
+    resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -5079,6 +5117,12 @@ packages:
   wawoff2@2.0.1:
     resolution: {integrity: sha512-r0CEmvpH63r4T15ebFqeOjGqU4+EgTx4I510NtK35EMciSdcTxCw3Byy3JnBonz7iyIFZ0AbVo0bbFpEVuhCYA==}
     hasBin: true
+
+  web-vitals@5.3.0:
+    resolution: {integrity: sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g==}
+
+  web-vitals@6.0.0:
+    resolution: {integrity: sha512-Guaibvy/+uNtL6Bsu4jmMJGzuSl91oeRH5iO9pPRbYftnFUr3yqT1TUNX/OE4o9HexuEMU3Kb/Wg7iKhlffZUA==}
 
   web-worker@1.5.0:
     resolution: {integrity: sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==}
@@ -7018,6 +7062,17 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
+  '@posthog/browser-common@0.5.2':
+    dependencies:
+      '@posthog/core': 1.48.11
+      '@posthog/types': 1.406.2
+
+  '@posthog/core@1.48.11':
+    dependencies:
+      '@posthog/types': 1.406.2
+
+  '@posthog/types@1.406.2': {}
+
   '@rolldown/binding-android-arm-eabi@1.2.5':
     optional: true
 
@@ -7257,6 +7312,9 @@ snapshots:
       csstype: 3.2.3
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -7919,6 +7977,8 @@ snapshots:
     dependencies:
       browserslist: 4.28.8
 
+  core-js@3.50.0: {}
+
   cosmiconfig@7.1.0:
     dependencies:
       '@types/parse-json': 4.0.2
@@ -8001,6 +8061,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.4.14:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dunder-proto@1.0.1:
     dependencies:
@@ -8453,6 +8517,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.7):
     optionalDependencies:
       picomatch: 4.0.7
+
+  fflate@0.4.9: {}
 
   figures@6.1.0:
     dependencies:
@@ -9756,6 +9822,23 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  posthog-js@1.417.1:
+    dependencies:
+      '@posthog/browser-common': 0.5.2
+      '@posthog/core': 1.48.11
+      '@posthog/types': 1.406.2
+      core-js: 3.50.0
+      dompurify: 3.4.14
+      fflate: 0.4.9
+      preact: 10.29.8
+      query-selector-shadow-dom: 1.0.1
+      web-vitals: 5.3.0
+      web-vitals-soft-navs: web-vitals@6.0.0
+    transitivePeerDependencies:
+      - preact-render-to-string
+
+  preact@10.29.8: {}
+
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.1:
@@ -9799,6 +9882,8 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@7.0.1: {}
+
+  query-selector-shadow-dom@1.0.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -10487,6 +10572,10 @@ snapshots:
   wawoff2@2.0.1:
     dependencies:
       argparse: 2.0.1
+
+  web-vitals@5.3.0: {}
+
+  web-vitals@6.0.0: {}
 
   web-worker@1.5.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ allowBuilds:
   '@swc/core': true
   esbuild: false
   unrs-resolver: false
+  core-js: false
   sharp: true
 packages:
   - apps/*

--- a/terraform/modules/posthog-proxy/main.tf
+++ b/terraform/modules/posthog-proxy/main.tf
@@ -1,0 +1,96 @@
+resource "google_service_account" "posthog_proxy" {
+  account_id   = "posthog-proxy"
+  display_name = "PostHog proxy"
+  description  = "Runtime identity of the PostHog proxy. It forwards to PostHog and holds no roles."
+  project      = var.project
+}
+
+resource "google_cloud_run_v2_service" "posthog_proxy" {
+  name     = "posthog-proxy"
+  location = var.location
+  project  = var.project
+
+  ingress             = "INGRESS_TRAFFIC_INTERNAL_LOAD_BALANCER"
+  deletion_protection = false
+
+  template {
+    service_account                  = google_service_account.posthog_proxy.email
+    max_instance_request_concurrency = 80
+
+    scaling {
+      max_instance_count = 4
+      min_instance_count = 0
+    }
+
+    containers {
+      image = var.image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        cpu_idle = true
+
+        limits = {
+          cpu    = "1"
+          memory = "256Mi"
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      client,
+      client_version,
+      template[0].containers[0].image,
+    ]
+  }
+}
+
+resource "google_cloud_run_v2_service_iam_member" "posthog_proxy" {
+  location = google_cloud_run_v2_service.posthog_proxy.location
+  name     = google_cloud_run_v2_service.posthog_proxy.name
+  project  = var.project
+
+  member = "allUsers"
+  role   = "roles/run.invoker"
+}
+
+resource "google_compute_region_network_endpoint_group" "posthog_proxy" {
+  name    = "posthog-proxy-network-endpoint-group"
+  project = var.project
+  region  = var.location
+
+  network_endpoint_type = "SERVERLESS"
+
+  cloud_run {
+    service = google_cloud_run_v2_service.posthog_proxy.name
+  }
+}
+
+resource "google_compute_backend_service" "posthog_proxy" {
+  name    = "posthog-proxy-backend-service"
+  project = var.project
+
+  load_balancing_scheme = "EXTERNAL"
+  timeout_sec           = 30
+
+  enable_cdn = false
+
+  log_config {
+    enable = false
+  }
+
+  backend {
+    group = google_compute_region_network_endpoint_group.posthog_proxy.id
+  }
+}
+
+resource "google_service_account_iam_binding" "posthog_proxy_deployers" {
+  service_account_id = google_service_account.posthog_proxy.name
+
+  members = toset(var.deployers)
+  role    = "roles/iam.serviceAccountUser"
+}

--- a/terraform/modules/posthog-proxy/outputs.tf
+++ b/terraform/modules/posthog-proxy/outputs.tf
@@ -1,0 +1,14 @@
+output "backend_service" {
+  value       = google_compute_backend_service.posthog_proxy.self_link
+  description = "Backend service the load balancer routes /psthg and /psthg/* to."
+}
+
+output "service" {
+  value       = google_cloud_run_v2_service.posthog_proxy.name
+  description = "Cloud Run service name."
+}
+
+output "service_account" {
+  value       = google_service_account.posthog_proxy
+  description = "Service account for the Cloud Run service."
+}

--- a/terraform/modules/posthog-proxy/readme.md
+++ b/terraform/modules/posthog-proxy/readme.md
@@ -1,0 +1,12 @@
+# posthog-proxy
+
+The first-party analytics endpoint. One Cloud Run service running the nginx
+image in `apps/posthog`, which forwards `/psthg/*` to PostHog EU Cloud, and the
+backend service the load balancer routes that path to.
+
+It egresses straight to the internet rather than over the VPC: the upstream is
+PostHog, not a service of ours. What it does not accept is traffic that has not
+come through the load balancer, so the `run.app` URL is not a way around the
+first-party path or the hosts it is published on.
+
+Terraform owns the shape of the service. CI owns what runs on it.

--- a/terraform/modules/posthog-proxy/variables.tf
+++ b/terraform/modules/posthog-proxy/variables.tf
@@ -1,0 +1,20 @@
+variable "deployers" {
+  default     = []
+  description = "Members that deploy revisions of the service and act as its runtime identity."
+  type        = list(string)
+}
+
+variable "image" {
+  type        = string
+  description = "Image the service is created with. Revisions are deployed from CI, so this only ever serves as a placeholder until the first one lands."
+}
+
+variable "location" {
+  type        = string
+  description = "Cloud Run service location."
+}
+
+variable "project" {
+  type        = string
+  description = "Project ID for the project where resources are configured."
+}

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -84,10 +84,11 @@ locals {
 
         production = {
           actions_variables = {
-            ASSETS_BUCKET = google_storage_bucket.public["production-assets"].name
-            ASSETS_URL    = local.host_urls["production-assets"]
-            BUCKET        = google_storage_bucket.public["production"].name
-            URL           = local.host_urls["production"]
+            ASSETS_BUCKET           = google_storage_bucket.public["production-assets"].name
+            ASSETS_URL              = local.host_urls["production-assets"]
+            BUCKET                  = google_storage_bucket.public["production"].name
+            NEXT_PUBLIC_POSTHOG_KEY = try(nonsensitive(module.secrets["posthog-proxy"].secret_data["posthog-project-token"]), "")
+            URL                     = local.host_urls["production"]
           }
         }
       }
@@ -182,6 +183,18 @@ locals {
   }
 
   secrets = {
+    "posthog-proxy" = {
+      project = module.project["edge"].project_id
+
+      secrets = [
+        "posthog-project-token",
+      ]
+
+      read_secret_version = var.posthog_project_token_version == "" ? {} : {
+        "posthog-project-token" = var.posthog_project_token_version
+      }
+    }
+
     "previews-router" = {
       project = module.project["edge"].project_id
 

--- a/terraform/web/main.tf
+++ b/terraform/web/main.tf
@@ -63,6 +63,9 @@ locals {
         for name, data in module.project :
         "${upper(name)}_PROJECT_ID" => data.project_id
         }, {
+        POSTHOG_PROXY_IMAGE    = "${lower(local.location)}-docker.pkg.dev/${module.project["build"].project_id}/${google_artifact_registry_repository.repository["docker"].repository_id}/posthog-proxy"
+        POSTHOG_PROXY_REGION   = local.region
+        POSTHOG_PROXY_SERVICE  = module.posthog_proxy.service
         PREVIEW_IMAGE          = "${lower(local.location)}-docker.pkg.dev/${module.project["build"].project_id}/${google_artifact_registry_repository.repository["docker"].repository_id}/web-previews"
         PREVIEW_REGION         = local.region
         PREVIEW_ROUTER_IMAGE   = "${lower(local.location)}-docker.pkg.dev/${module.project["build"].project_id}/${google_artifact_registry_repository.repository["docker"].repository_id}/preview-router"

--- a/terraform/web/posthog-proxy.tf
+++ b/terraform/web/posthog-proxy.tf
@@ -1,0 +1,8 @@
+module "posthog_proxy" {
+  source = "../modules/posthog-proxy"
+
+  deployers = ["serviceAccount:${module.github["langri-sha.com"].service_account.email}"]
+  image     = var.posthog_proxy_image
+  location  = local.region
+  project   = module.project["edge"].project_id
+}

--- a/terraform/web/secrets.tf
+++ b/terraform/web/secrets.tf
@@ -3,7 +3,8 @@ module "secrets" {
 
   source = "github.com/langri-sha/terraform-google-cloud-platform//modules/secrets?ref=v0.12.0"
 
-  project = each.value.project
-  secrets = each.value.secrets
-  topic   = each.key
+  project             = each.value.project
+  read_secret_version = try(each.value.read_secret_version, {})
+  secrets             = each.value.secrets
+  topic               = each.key
 }

--- a/terraform/web/tests/url-map.tftest.hcl
+++ b/terraform/web/tests/url-map.tftest.hcl
@@ -1,3 +1,7 @@
+variables {
+  posthog_project_token_version = ""
+}
+
 mock_provider "google" {
   mock_resource "google_service_account" {
     defaults = {

--- a/terraform/web/tests/url-map.tftest.hcl
+++ b/terraform/web/tests/url-map.tftest.hcl
@@ -1,0 +1,152 @@
+mock_provider "google" {
+  mock_resource "google_service_account" {
+    defaults = {
+      id   = "projects/edge-0000/serviceAccounts/mock-account@edge-0000.iam.gserviceaccount.com"
+      name = "projects/edge-0000/serviceAccounts/mock-account@edge-0000.iam.gserviceaccount.com"
+    }
+  }
+
+  mock_data "google_iam_policy" {
+    defaults = {
+      policy_data = "{}"
+    }
+  }
+}
+
+mock_provider "google-beta" {}
+
+mock_provider "random" {}
+
+mock_provider "github" {
+  mock_data "github_repository" {
+    defaults = {
+      full_name = "langri-sha/langri-sha.com"
+      name      = "langri-sha.com"
+    }
+  }
+}
+
+override_data {
+  target = data.terraform_remote_state.org
+
+  values = {
+    outputs = {
+      admin_members             = ["user:someone@example.com"]
+      billing_account           = "000000-000000-000000"
+      dns_managed_zone          = "example"
+      domain                    = "example.com"
+      location                  = "EU"
+      org_id                    = "000000000000"
+      org_project_id            = "org-0000"
+      region                    = "europe-west1"
+      web_folder                = "folders/000000000000"
+      web_service_account_email = "web@org-0000.iam.gserviceaccount.com"
+      zone                      = "europe-west1-b"
+    }
+  }
+}
+
+override_module {
+  target = module.project["build"]
+
+  outputs = {
+    project_id     = "build-0000"
+    project_number = "100000000000"
+  }
+}
+
+override_module {
+  target = module.project["edge"]
+
+  outputs = {
+    project_id     = "edge-0000"
+    project_number = "200000000000"
+  }
+}
+
+run "analytics_reach_the_proxy_on_every_host_that_serves_the_site" {
+  command = apply
+
+  assert {
+    condition = alltrue([
+      for host in ["preview", "production"] :
+      length([
+        for matcher in google_compute_url_map.default.path_matcher :
+        matcher
+        if matcher.name == host
+      ]) == 1
+    ])
+    error_message = "The production and preview hosts must each have a path matcher of their own."
+  }
+
+  assert {
+    condition = alltrue([
+      for host in ["preview", "production"] :
+      setunion([], flatten([
+        for matcher in google_compute_url_map.default.path_matcher : [
+          for rule in matcher.path_rule :
+          rule.paths
+          if rule.service == module.posthog_proxy.backend_service
+        ]
+        if matcher.name == host
+      ])) == toset(["/psthg", "/psthg/*"])
+    ])
+    error_message = "Both /psthg and /psthg/* must reach the proxy on the production and preview hosts. A wildcard alone leaves the bare path on the host's own backend."
+  }
+
+  assert {
+    condition = alltrue([
+      for matcher in google_compute_url_map.default.path_matcher :
+      matcher.default_service != module.posthog_proxy.backend_service
+    ])
+    error_message = "No host may fall back to the proxy: it answers for /psthg and nothing else."
+  }
+
+  assert {
+    condition = alltrue(flatten([
+      for matcher in google_compute_url_map.default.path_matcher : [
+        for rule in matcher.path_rule :
+        try(length(rule.route_action), 0) == 0 && try(length(rule.url_redirect), 0) == 0
+      ]
+    ]))
+    error_message = "The proxy is mounted at /psthg and strips that prefix itself. A rule that rewrites or redirects the path hands it something it answers with a 404."
+  }
+
+  assert {
+    condition = alltrue([
+      for matcher in google_compute_url_map.default.path_matcher :
+      length(matcher.path_rule) == 0
+      if !contains(["preview", "production"], matcher.name)
+    ])
+    error_message = "Hosts that serve no HTML make no analytics requests, and must carry no path rules."
+  }
+}
+
+run "the_proxy_hosts_are_the_ones_the_site_is_published_on" {
+  command = apply
+
+  assert {
+    condition = alltrue([
+      for rule in google_compute_url_map.default.host_rule :
+      contains(rule.hosts, "example.com") ? rule.path_matcher == "production" : true
+    ])
+    error_message = "The apex must be matched by the production path matcher, which is the one carrying the /psthg rules."
+  }
+
+  assert {
+    condition = alltrue([
+      for rule in google_compute_url_map.default.host_rule :
+      contains(rule.hosts, "preview.example.com") ? rule.path_matcher == "preview" : true
+    ])
+    error_message = "The preview host must be matched by the preview path matcher, which is the one carrying the /psthg rules."
+  }
+
+  assert {
+    condition = length([
+      for rule in google_compute_url_map.default.host_rule :
+      rule
+      if contains(rule.hosts, "example.com") || contains(rule.hosts, "preview.example.com")
+    ]) == 2
+    error_message = "Both hosts must have a rule in the URL map. A host without one answers from the map's default, not from its matcher."
+  }
+}

--- a/terraform/web/traffic.tf
+++ b/terraform/web/traffic.tf
@@ -18,6 +18,10 @@ locals {
       "preview" = module.previews_router.backend_service
     }
   )
+
+  posthog_proxy_hosts = ["preview", "production"]
+
+  posthog_proxy_paths = ["/psthg", "/psthg/*"]
 }
 
 resource "google_compute_global_address" "default" {
@@ -147,6 +151,15 @@ resource "google_compute_url_map" "default" {
     content {
       name            = path_matcher.value
       default_service = local.host_backends[path_matcher.value]
+
+      dynamic "path_rule" {
+        for_each = contains(local.posthog_proxy_hosts, path_matcher.value) ? [1] : []
+
+        content {
+          paths   = local.posthog_proxy_paths
+          service = module.posthog_proxy.backend_service
+        }
+      }
     }
   }
 }

--- a/terraform/web/variables.tf
+++ b/terraform/web/variables.tf
@@ -1,3 +1,9 @@
+variable "posthog_proxy_image" {
+  default     = "us-docker.pkg.dev/cloudrun/container/hello"
+  description = "Image the PostHog proxy service is created with. Revisions are deployed from CI, so this only ever serves as a placeholder until the first one lands."
+  type        = string
+}
+
 variable "preview_image" {
   default     = "us-docker.pkg.dev/cloudrun/container/hello"
   description = "Image the preview origin service is created with. Revisions are deployed from CI, one per preview, so this only ever serves as a placeholder until the first one lands."

--- a/terraform/web/variables.tf
+++ b/terraform/web/variables.tf
@@ -1,3 +1,9 @@
+variable "posthog_project_token_version" {
+  default     = "latest"
+  description = "Version of the posthog-project-token secret to read. Empty skips the read, which the URL map test needs: a mocked provider cannot resolve it at plan time."
+  type        = string
+}
+
 variable "posthog_proxy_image" {
   default     = "us-docker.pkg.dev/cloudrun/container/hello"
   description = "Image the PostHog proxy service is created with. Revisions are deployed from CI, so this only ever serves as a placeholder until the first one lands."


### PR DESCRIPTION
Browser analytics reach PostHog EU through our own origin at `/psthg/` rather
than a PostHog host. The site is a static export on Cloud Storage, so there is
no Next.js runtime to hold the `rewrites()` rule PostHog documents — this is
that rule, as an nginx image on Cloud Run wired into the existing load balancer
as a serverless NEG, reached only through the `/psthg` path rules.

Both `/psthg` and `/psthg/*` are routed on the production **and** the preview
host. A wildcard alone matches only what follows the prefix, and the production
matcher does not cover previews, so each is asserted separately in
`terraform/web/tests/url-map.tftest.hcl` — providers are mocked and the org
state stood in for, so it runs on a pull request without credentials.

The project token lives in Secret Manager as `posthog-project-token`. Terraform
creates it and grants the release workflow read access; the build reads it and
bakes it into the bundle. It is public by design — it identifies the project and
cannot read data back out — but it stays out of git, and rotating it is a new
secret version rather than a commit. A release before a version exists builds
without analytics rather than failing, which is what every preview build does.

Cookies are stripped outbound and `Set-Cookie` dropped inbound, upstream
certificates are verified, query strings stay out of both the access log and the
load balancer log, and capture is held to pageviews — autocapture, heatmaps,
session recording and exception capture are all off. The US origins appear
nowhere in the image.

One trade-off worth naming: the preview host's `/psthg` rule bypasses the
previews router and its IAP. It exposes only the same public proxy production
already serves, no preview content.

## Test plan

- `pnpm test`, `pnpm build`, `tsc --build`, `eslint`, `prettier`
- `terraform fmt -check`, `validate` and `test` in `terraform/web` on 1.15.9
- The proxy workflow stands up a stub answering for both PostHog origins and
  asserts the origin selected, the stripped path, the `Host` it arrived with,
  the headers forwarded and refused, and that an untrusted upstream certificate
  answers 502

## Deploying

Order matters — the site must not start sending events before there is a
revision to answer them.

1. `terraform apply` in `terraform/web` creates the Cloud Run service, the
   serverless NEG, the backend service, the CI read grant and the `/psthg` path
   rules. The service starts on Google's `hello` placeholder, so `/psthg/*`
   answers with nothing useful. Run this before merging: the apply is what
   publishes `POSTHOG_PROXY_SERVICE`, and without it the publish job skips.
2. Merging publishes the image and deploys the first real revision.
3. Cutting a release rebuilds the site with the token and analytics start.

The `posthog-project-token` secret already exists and has a version.

Closes #1275
