### PR TITLE
Declare the glsl ambient module type

### DIFF
--- a/apps/web/src/web.d.ts
+++ b/apps/web/src/web.d.ts
@@ -18,6 +18,12 @@ declare module '*.css' {
   export default content
 }
 
+declare module '*.glsl' {
+  const content: string
+
+  export default content
+}
+
 declare module '*.frag' {
   const content: string
 


### PR DESCRIPTION
The webpack loader config already routes `*.glsl` files through `raw-loader`, but `web.d.ts` was missing the matching ambient module declaration, so importing a `.glsl` file failed typecheck.