### PR TITLE
Remove the dead experimental scene flag

### DIFF
--- a/apps/web/src/app/lib/landing.tsx
+++ b/apps/web/src/app/lib/landing.tsx
@@ -20,7 +20,7 @@ export const Landing: React.FC = () => {
         <Root>
           {/* The scene paints first so the header, which follows it in the
               flow, sits on top without an isolating z-index. */}
-          {process.env.EXPERIMENTAL_SCENE ? <Scene /> : null}
+          <Scene />
           <Header />
           {playing ? <Drone /> : null}
           <Play

--- a/apps/web/src/web.d.ts
+++ b/apps/web/src/web.d.ts
@@ -2,8 +2,6 @@
 
 declare type WebEnv = {
   NODE_ENV: 'development' | 'production'
-  /** Add experimental scene to landing page, when set. */
-  EXPERIMENTAL_SCENE: string | null
 }
 
 declare global {


### PR DESCRIPTION
`EXPERIMENTAL_SCENE` has been dead since the webpack config that defined it was retired — Next only inlines `NEXT_PUBLIC_*` into the client bundle — so the landing scene never mounted. This drops the gate and the stale `WebEnv` declaration.

Note that the scene on `main` is still the placeholder shader, so it becomes visible until the shader work lands.