### PR TITLE
Stop the header animation from isolating its contents

### DIFF
--- a/apps/web/src/app/lib/header/index.tsx
+++ b/apps/web/src/app/lib/header/index.tsx
@@ -54,8 +54,10 @@ export const Header: React.FC = () => (
   </Root>
 )
 
+// The entrance animation lives on the children rather than here: an animated
+// transform and opacity form a stacking context for as long as they run, which
+// would isolate everything inside the header from the scene painted behind it.
 const Root = styled.header`
-  ${animations.booming};
   position: relative;
 `
 
@@ -66,6 +68,7 @@ const Title = styled.h1`
 `
 
 const Nav = styled.nav`
+  ${animations.booming};
   display: flex;
   width: 100%;
   left: 0;

--- a/apps/web/src/app/lib/header/wordmark.tsx
+++ b/apps/web/src/app/lib/header/wordmark.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 import * as React from 'react'
 
-import { colors } from '@/styles'
+import { animations, colors } from '@/styles'
 
 // Wordmark hand-traced from the "Cinzel Decorative" typeface
 // by Natanael Gama, under the SIL Open Font License 1.1.
@@ -23,6 +23,7 @@ const WordmarkMark: React.FC<{ className?: string }> = ({ className }) => (
 )
 
 export const Wordmark = styled(WordmarkMark)`
+  ${animations.booming};
   color: ${colors.text};
   display: block;
   width: 100%;


### PR DESCRIPTION
## Summary

The header's entrance animation put a stacking context around everything inside
it for its first three seconds. An animated `transform` and `opacity` form one
for as long as they run, so while it played the wordmark and nav were an
isolated group, cut off from the scene painted behind them. Anything inside the
header that wants to composite against that backdrop — a `mix-blend-mode`, say
— silently did nothing until the animation finished, which is precisely the
moment the header is most visible.

Moving the animation onto the wordmark and the nav removes the isolation: an
element's own stacking context does not isolate the element itself. Both
children run the same keyframes for the same duration, so the entrance is
unchanged.

This is the remaining half of the layering work started in b0fe5c3a, which
dropped the header's `z-index` for the same reason and let document order keep
it above the scene.

## Changes

- `header/index.tsx` — `animations.booming` moves off `Root` onto `Nav`, with a
  comment recording why it must not drift back up
- `header/wordmark.tsx` — `Wordmark` takes the same animation

## Test plan

- Load the landing page: the header still fades and scales in over 3s, with the
  motion unchanged.
- Pause the entrance animation mid-flight and walk the wordmark's ancestor
  chain — `h1 → header → div → div → body → html`. No ancestor forms a stacking
  context. Before this change, `header` appeared there with a running animation
  for the full three seconds.
