### PR TITLE
Recreate the landing gradient as a WebGL shader

### DIFF
--- a/apps/web/src/components/scene/default.frag
+++ b/apps/web/src/components/scene/default.frag
@@ -1,9 +1,127 @@
-// fragment shaders don't have a default precision so we need
-// to pick one. mediump is a good default
+// Recreates the landing page background. The CSS stacks two identical
+// `Root::before` aurora gradients with `mix-blend-mode: color-dodge` — the
+// outer one composites over a transparent backdrop, so the visible result is
+// the aurora radial gradient color-dodged over itself. The pool gradient in
+// the CSS sits beneath the opaque aurora layer and never shows.
+
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
 precision mediump float;
+#endif
+
+uniform vec2 u_resolution;
+uniform float u_time;
+
+// One `drift` keyframe: the aurora ellipse in viewport fractions (CSS
+// percentages / 100, y pointing down) and its palette in sRGB.
+struct Aurora {
+  vec2 center;
+  vec2 radius;
+  vec3 violet;
+  vec3 magenta;
+  vec3 indigo;
+  vec3 mist;
+};
+
+// Seconds per pass through the keyframes, as in `animation: drift 48s`.
+const float DURATION = 48.0;
+
+float linstep(float edge0, float edge1, float x) {
+  return clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+}
+
+// Approximates the CSS `ease-in-out` timing function.
+float easeInOut(float t) {
+  return t * t * (3.0 - 2.0 * t);
+}
+
+Aurora blend(Aurora source, Aurora target, float t) {
+  return Aurora(
+    mix(source.center, target.center, t),
+    mix(source.radius, target.radius, t),
+    mix(source.violet, target.violet, t),
+    mix(source.magenta, target.magenta, t),
+    mix(source.indigo, target.indigo, t),
+    mix(source.mist, target.mist, t)
+  );
+}
+
+// Plays back the `drift` keyframes: ease-in-out between each pair,
+// alternating direction every pass.
+Aurora drift(float time) {
+  Aurora from = Aurora(
+    vec2(0.0, 0.0),
+    vec2(1.4, 1.4),
+    vec3(61.0, 27.0, 109.0) / 255.0,
+    vec3(228.0, 56.0, 220.0) / 255.0,
+    vec3(64.0, 75.0, 140.0) / 255.0,
+    vec3(121.0, 172.0, 187.0) / 255.0
+  );
+
+  Aurora third = Aurora(
+    vec2(0.12, 0.08),
+    vec2(1.65, 1.2),
+    vec3(74.0, 26.0, 134.0) / 255.0,
+    vec3(255.0, 47.0, 146.0) / 255.0,
+    vec3(61.0, 91.0, 176.0) / 255.0,
+    vec3(77.0, 215.0, 232.0) / 255.0
+  );
+
+  Aurora twoThirds = Aurora(
+    vec2(0.04, 0.18),
+    vec2(1.2, 1.7),
+    vec3(51.0, 32.0, 110.0) / 255.0,
+    vec3(196.0, 51.0, 255.0) / 255.0,
+    vec3(74.0, 63.0, 158.0) / 255.0,
+    vec3(98.0, 184.0, 217.0) / 255.0
+  );
+
+  Aurora to = Aurora(
+    vec2(0.16, 0.04),
+    vec2(1.5, 1.35),
+    vec3(61.0, 27.0, 109.0) / 255.0,
+    vec3(240.0, 56.0, 200.0) / 255.0,
+    vec3(64.0, 75.0, 140.0) / 255.0,
+    vec3(121.0, 172.0, 187.0) / 255.0
+  );
+
+  float cycle = mod(time / DURATION, 2.0);
+  float progress = cycle < 1.0 ? cycle : 2.0 - cycle;
+
+  if (progress < 0.33) {
+    return blend(from, third, easeInOut(progress / 0.33));
+  }
+
+  if (progress < 0.66) {
+    return blend(third, twoThirds, easeInOut((progress - 0.33) / 0.33));
+  }
+
+  return blend(twoThirds, to, easeInOut((progress - 0.66) / 0.34));
+}
+
+// The aurora radial gradient, with the color stops from the CSS:
+// violet 30%, magenta 65%, indigo 80%, mist 110%.
+vec3 gradient(Aurora aurora, vec2 point) {
+  float t = length((point - aurora.center) / aurora.radius);
+
+  vec3 color = mix(aurora.violet, aurora.magenta, linstep(0.3, 0.65, t));
+  color = mix(color, aurora.indigo, linstep(0.65, 0.8, t));
+
+  return mix(color, aurora.mist, linstep(0.8, 1.1, t));
+}
+
+vec3 colorDodge(vec3 backdrop, vec3 source) {
+  return min(vec3(1.0), backdrop / max(1.0 - source, 1e-4));
+}
 
 void main() {
-  // gl_FragColor is a special variable a fragment shader
-  // is responsible for setting
-  gl_FragColor = vec4(1, 0, 0.5, 1); // return redish-purple
+  // CSS coordinates: origin top left, y pointing down.
+  vec2 point = gl_FragCoord.xy / u_resolution;
+  point.y = 1.0 - point.y;
+
+  Aurora aurora = drift(u_time);
+  vec3 color = gradient(aurora, point);
+
+  gl_FragColor = vec4(colorDodge(color, color), 1.0);
 }

--- a/apps/web/src/components/scene/index.tsx
+++ b/apps/web/src/components/scene/index.tsx
@@ -4,69 +4,127 @@ import * as React from 'react'
 import fragmentShaderSource from './default.frag'
 import vertexShaderSource from './default.vert'
 
+// One pass through the `drift` keyframes and back (48s, alternating), after
+// which the animation repeats exactly.
+const CYCLE = 96
+
 export const Scene: React.FC = () => {
   const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
 
   React.useEffect(() => {
-    if (!canvasRef.current) return
+    const canvas = canvasRef.current
+    if (!canvas) return
 
-    const gl = canvasRef.current.getContext('webgl')
+    const gl = canvas.getContext('webgl')
     if (!gl) return
 
-    const vertexShader = createShader(gl, gl.VERTEX_SHADER, vertexShaderSource)
-    const fragmentShader = createShader(
-      gl,
-      gl.FRAGMENT_SHADER,
-      fragmentShaderSource,
-    )
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
 
-    if (!vertexShader || !fragmentShader) {
-      return
+    let frame = 0
+    let dispose: (() => void) | null = null
+
+    const setup = () => {
+      const vertexShader = createShader(
+        gl,
+        gl.VERTEX_SHADER,
+        vertexShaderSource,
+      )
+      const fragmentShader = createShader(
+        gl,
+        gl.FRAGMENT_SHADER,
+        fragmentShaderSource,
+      )
+
+      if (!vertexShader || !fragmentShader) {
+        return
+      }
+
+      const program = createProgram(gl, vertexShader, fragmentShader)
+
+      if (!program) {
+        return
+      }
+
+      // A single triangle covering clip space.
+      const positions = [-1, -1, 3, -1, -1, 3]
+      const positionAttributeLocation = gl.getAttribLocation(
+        program,
+        'a_position',
+      )
+      const positionBuffer = gl.createBuffer()
+      gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer)
+      gl.bufferData(
+        gl.ARRAY_BUFFER,
+        new Float32Array(positions),
+        gl.STATIC_DRAW,
+      )
+
+      gl.useProgram(program)
+      gl.enableVertexAttribArray(positionAttributeLocation)
+      gl.vertexAttribPointer(
+        positionAttributeLocation,
+        2,
+        gl.FLOAT,
+        false,
+        0,
+        0,
+      )
+
+      const resolutionLocation = gl.getUniformLocation(program, 'u_resolution')
+      const timeLocation = gl.getUniformLocation(program, 'u_time')
+
+      const render = (now: DOMHighResTimeStamp) => {
+        resize(canvas)
+
+        gl.viewport(0, 0, gl.canvas.width, gl.canvas.height)
+        gl.uniform2f(resolutionLocation, gl.canvas.width, gl.canvas.height)
+        // Wrapped to the animation cycle so shader float precision holds up
+        // as the clock grows.
+        gl.uniform1f(
+          timeLocation,
+          reducedMotion.matches ? 0 : (now / 1000) % CYCLE,
+        )
+        gl.drawArrays(gl.TRIANGLES, 0, 3)
+
+        frame = requestAnimationFrame(render)
+      }
+
+      frame = requestAnimationFrame(render)
+
+      dispose = () => {
+        cancelAnimationFrame(frame)
+        gl.deleteBuffer(positionBuffer)
+        gl.deleteProgram(program)
+        gl.deleteShader(vertexShader)
+        gl.deleteShader(fragmentShader)
+      }
     }
 
-    const program = createProgram(gl, vertexShader, fragmentShader)
-
-    if (!program) {
-      return
+    // The browser can evict the context under GPU pressure, leaving the
+    // canvas as an opaque broken-canvas placeholder. Hide it so the CSS
+    // gradient shows through until the context comes back.
+    const handleContextLost = (event: Event) => {
+      event.preventDefault()
+      dispose?.()
+      dispose = null
+      canvas.style.visibility = 'hidden'
     }
 
-    const positions = [0, 0, 0, 0.5, 0.7, 0]
-    const positionAttributeLocation = gl.getAttribLocation(
-      program,
-      'a_position',
-    )
-    const positionBuffer = gl.createBuffer()
-    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer)
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(positions), gl.STATIC_DRAW)
+    const handleContextRestored = () => {
+      canvas.style.visibility = ''
+      setup()
+    }
 
-    resize(canvasRef.current)
-    gl.viewport(0, 0, gl.canvas.width, gl.canvas.height)
+    canvas.addEventListener('webglcontextlost', handleContextLost)
+    canvas.addEventListener('webglcontextrestored', handleContextRestored)
 
-    gl.clearColor(0, 0, 0, 0)
-    gl.clear(gl.COLOR_BUFFER_BIT)
+    setup()
 
-    gl.useProgram(program)
-
-    gl.enableVertexAttribArray(positionAttributeLocation)
-    // Bind the position buffer.
-    gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer)
-    const size = 2 // 2 components per iteration
-    const type = gl.FLOAT // The data is 32bit floats
-    const normalize = false // Don't normalize the data
-    const stride = 0 // 0 = move forward size * sizeof(type) each iteration to get the next position
-    gl.vertexAttribPointer(
-      positionAttributeLocation,
-      size,
-      type,
-      normalize,
-      stride,
-      0,
-    )
-
-    const primitiveType = gl.TRIANGLES
-    const offset = 0
-    const count = 3
-    gl.drawArrays(primitiveType, offset, count)
+    return () => {
+      canvas.removeEventListener('webglcontextlost', handleContextLost)
+      canvas.removeEventListener('webglcontextrestored', handleContextRestored)
+      dispose?.()
+    }
   }, [])
 
   return <Canvas ref={canvasRef} />


### PR DESCRIPTION
`Scene` already mounts unconditionally on `main`, but its fragment shader is still the WebGL-fundamentals placeholder — a pink triangle. This replaces it with a shader that reproduces the existing CSS `drift` animation: the aurora radial gradient with the CSS colour stops, colour-dodged over itself to match the two stacked `Root::before` layers, drawn on a fullscreen clip-space triangle by a rAF loop that tracks canvas size and DPR.

The CSS gradient stays in place as the fallback — the canvas hides while the WebGL context is lost and GL state is rebuilt on restore. Time freezes under `prefers-reduced-motion`.
