### PR TITLE
Stop Next from generating agent rule files

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next'
 
 const config: NextConfig = {
+  agentRules: false,
   assetPrefix: process.env.ASSETS_URL,
   basePath: process.env.BASE_PATH,
   distDir: 'dist',


### PR DESCRIPTION
Next 16.3 started writing AGENTS.md and CLAUDE.md into apps/web on dev-server startup. This turns that off, since the repo has its own agent conventions.