### PR TITLE
Replace the landing background with the rift scene and its invocation

### DIFF
--- a/apps/web/src/app/lib/header/index.tsx
+++ b/apps/web/src/app/lib/header/index.tsx
@@ -54,9 +54,10 @@ export const Header: React.FC = () => (
   </Root>
 )
 
-// The entrance animation lives on the children rather than here: an animated
-// transform and opacity form a stacking context for as long as they run, which
-// would isolate everything inside the header from the scene painted behind it.
+// Deliberately no z-index, and the entrance animation lives on the children
+// rather than here: either would make the header an isolated group, leaving the
+// wordmark's blend with nothing to mix against. Painting after the scene in the
+// flow is enough to keep it on top.
 const Root = styled.header`
   position: relative;
 `

--- a/apps/web/src/app/lib/header/wordmark.tsx
+++ b/apps/web/src/app/lib/header/wordmark.tsx
@@ -22,10 +22,13 @@ const WordmarkMark: React.FC<{ className?: string }> = ({ className }) => (
   </svg>
 )
 
+// The entrance animation belongs here rather than on an ancestor: an element's
+// own stacking context does not isolate it, so the blend survives the zoom-in.
 export const Wordmark = styled(WordmarkMark)`
   ${animations.booming};
   color: ${colors.text};
   display: block;
   width: 100%;
   height: auto;
+  mix-blend-mode: luminosity;
 `

--- a/apps/web/src/app/lib/landing.tsx
+++ b/apps/web/src/app/lib/landing.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 'use client'
 
-import { Global, css, keyframes } from '@emotion/react'
+import { Global, css } from '@emotion/react'
 import styled from '@emotion/styled'
 import * as React from 'react'
 
@@ -16,7 +16,7 @@ export const Landing: React.FC = () => {
 
   return (
     <React.Fragment>
-      <Global styles={[global, gradientProperties]} />
+      <Global styles={[global, backdrop]} />
       <Root>
         <Root>
           {/* The scene paints first so the header, which follows it in the
@@ -34,142 +34,32 @@ export const Landing: React.FC = () => {
   )
 }
 
-const gradientProperties = css`
-  /* Aurora */
-  @property --aurora-x {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 0%;
-  }
-
-  @property --aurora-y {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 0%;
-  }
-
-  @property --aurora-rx {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 140%;
-  }
-
-  @property --aurora-ry {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 140%;
-  }
-
-  /* Pool */
-  @property --pool-x {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 60%;
-  }
-
-  @property --pool-y {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 50%;
-  }
-
-  @property --pool-stop {
-    syntax: '<percentage>';
-    inherits: true;
-    initial-value: 20%;
-  }
-
-  /* Palette */
-  @property --violet {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #3d1b6d;
-  }
-
-  @property --magenta {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #e438dc;
-  }
-
-  @property --indigo {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #404b8c;
-  }
-
-  @property --mist {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #79acbb;
-  }
-
-  @property --pool {
-    syntax: '<color>';
-    inherits: true;
-    initial-value: #7f4dad;
-  }
-`
-
-const drift = keyframes`
-  0% {
-    --aurora-x: 0%;
-    --aurora-y: 0%;
-    --aurora-rx: 140%;
-    --aurora-ry: 140%;
-    --pool-x: 60%;
-    --pool-y: 50%;
-    --pool-stop: 20%;
-    --violet: #3d1b6d;
-    --magenta: #e438dc;
-    --indigo: #404b8c;
-    --mist: #79acbb;
-    --pool: #7f4dad;
-  }
-
-  33% {
-    --aurora-x: 12%;
-    --aurora-y: 8%;
-    --aurora-rx: 165%;
-    --aurora-ry: 120%;
-    --pool-x: 50%;
-    --pool-y: 42%;
-    --pool-stop: 32%;
-    --violet: #4a1a86;
-    --magenta: #ff2f92;
-    --indigo: #3d5bb0;
-    --mist: #4dd7e8;
-    --pool: #9a3df0;
-  }
-
-  66% {
-    --aurora-x: 4%;
-    --aurora-y: 18%;
-    --aurora-rx: 120%;
-    --aurora-ry: 170%;
-    --pool-x: 66%;
-    --pool-y: 58%;
-    --pool-stop: 26%;
-    --violet: #33206e;
-    --magenta: #c433ff;
-    --indigo: #4a3f9e;
-    --mist: #62b8d9;
-    --pool: #b03ddb;
-  }
-
-  100% {
-    --aurora-x: 16%;
-    --aurora-y: 4%;
-    --aurora-rx: 150%;
-    --aurora-ry: 135%;
-    --pool-x: 56%;
-    --pool-y: 48%;
-    --pool-stop: 22%;
-    --violet: #3d1b6d;
-    --magenta: #f038c8;
-    --indigo: #404b8c;
-    --mist: #79acbb;
-    --pool: #8748c4;
+// A static approximation of the shader's deep-space background. It paints the
+// very first frame — before the bundle loads and the WebGL scene mounts — so
+// the rift appears to kick in instantly, and it remains the fallback wherever
+// WebGL is unavailable.
+const backdrop = css`
+  body {
+    background:
+      radial-gradient(
+          ellipse 70% 28% at 50% 30%,
+          rgba(90, 8, 36, 0.35),
+          transparent 70%
+        )
+        no-repeat,
+      radial-gradient(
+          ellipse 80% 34% at 50% 66%,
+          rgba(18, 60, 165, 0.3),
+          transparent 70%
+        )
+        no-repeat,
+      radial-gradient(
+          ellipse 130% 100% at 50% 48%,
+          #070d22 0%,
+          #030614 55%,
+          #010208 100%
+        )
+        no-repeat;
   }
 `
 
@@ -180,51 +70,4 @@ const Root = styled.div`
   flex-flow: column nowrap;
   align-items: center;
   justify-content: center;
-
-  &::before {
-    content: '';
-    position: absolute;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    mix-blend-mode: color-dodge;
-    background:
-      radial-gradient(
-          ellipse var(--aurora-rx) var(--aurora-ry) at var(--aurora-x)
-            var(--aurora-y),
-          var(--violet) 30%,
-          var(--magenta) 65%,
-          var(--indigo) 80%,
-          var(--mist) 110%
-        )
-        no-repeat,
-      radial-gradient(
-          closest-side at var(--pool-x) var(--pool-y),
-          var(--pool) var(--pool-stop),
-          #000 100%
-        )
-        no-repeat,
-      radial-gradient(
-          ellipse var(--aurora-rx) var(--aurora-ry) at var(--aurora-x)
-            var(--aurora-y),
-          var(--violet) 30%,
-          var(--magenta) 65%,
-          var(--indigo) 80%,
-          var(--mist) 110%
-        )
-        no-repeat,
-      radial-gradient(
-          closest-side at var(--pool-x) var(--pool-y),
-          var(--pool) var(--pool-stop),
-          #000 100%
-        )
-        no-repeat;
-    animation: ${drift} 48s ease-in-out infinite alternate;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    &::before {
-      animation: none;
-    }
-  }
 `

--- a/apps/web/src/app/lib/landing.tsx
+++ b/apps/web/src/app/lib/landing.tsx
@@ -12,6 +12,7 @@ import { Header } from './header'
 
 export const Landing: React.FC = () => {
   const [playing, setPlaying] = React.useState(false)
+  const audioLevelRef = React.useRef(0)
 
   return (
     <React.Fragment>
@@ -20,9 +21,9 @@ export const Landing: React.FC = () => {
         <Root>
           {/* The scene paints first so the header, which follows it in the
               flow, sits on top without an isolating z-index. */}
-          <Scene />
+          <Scene audioLevelRef={audioLevelRef} />
           <Header />
-          {playing ? <Drone /> : null}
+          {playing ? <Drone audioLevelRef={audioLevelRef} /> : null}
           <Play
             playing={playing}
             onToggle={() => setPlaying((current) => !current)}

--- a/apps/web/src/app/lib/landing.tsx
+++ b/apps/web/src/app/lib/landing.tsx
@@ -20,7 +20,7 @@ export const Landing: React.FC = () => {
       <Root>
         <Root>
           {/* The scene paints first so the header, which follows it in the
-              flow, sits on top without an isolating z-index. */}
+              flow, can blend against it without an isolating z-index. */}
           <Scene audioLevelRef={audioLevelRef} starOnly />
           <Header />
           {playing ? <Drone audioLevelRef={audioLevelRef} /> : null}

--- a/apps/web/src/app/lib/landing.tsx
+++ b/apps/web/src/app/lib/landing.tsx
@@ -21,7 +21,7 @@ export const Landing: React.FC = () => {
         <Root>
           {/* The scene paints first so the header, which follows it in the
               flow, sits on top without an isolating z-index. */}
-          <Scene audioLevelRef={audioLevelRef} />
+          <Scene audioLevelRef={audioLevelRef} starOnly />
           <Header />
           {playing ? <Drone audioLevelRef={audioLevelRef} /> : null}
           <Play

--- a/apps/web/src/app/shape/page.tsx
+++ b/apps/web/src/app/shape/page.tsx
@@ -1,0 +1,7 @@
+// The full scene, but with the rift reduced to its bare star — a page for
+// judging the shape in situ, with every light and glow that surrounds it.
+import { ShapePreview } from './preview'
+
+const Page = () => <ShapePreview />
+
+export default Page

--- a/apps/web/src/app/shape/preview.tsx
+++ b/apps/web/src/app/shape/preview.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { Global } from '@emotion/react'
+import * as React from 'react'
+
+import { Scene } from '@/components/scene'
+import { global } from '@/styles'
+
+export const ShapePreview: React.FC = () => (
+  <React.Fragment>
+    <Global styles={global} />
+    <Scene starOnly />
+  </React.Fragment>
+)

--- a/apps/web/src/components/drone.tsx
+++ b/apps/web/src/components/drone.tsx
@@ -6,13 +6,17 @@ import noiseProcessorSource from './noise-processor.worklet'
 
 let voicePlayed = false
 
-export const Drone: React.FC<Record<string, never>> = () => {
-  React.useEffect(() => {
+export interface DroneProps {
+  audioLevelRef: React.MutableRefObject<number>
+}
+
+export const Drone: React.FC<DroneProps> = ({ audioLevelRef }) => {
+  React.useLayoutEffect(() => {
     if (!window.AudioContext) {
       return
     }
 
-    const processor = new Processor()
+    const processor = new Processor(audioLevelRef)
 
     processor.generate().catch(() => {
       // AudioWorklet failed to load (e.g. unsupported browser); nothing to play.
@@ -38,19 +42,31 @@ class Processor {
   gainNode: GainNode
   droneBus: GainNode
   voice: Voice | null = null
+  analyserNode: AnalyserNode
+  audioLevelRef: React.MutableRefObject<number>
+  frequencyData: Uint8Array<ArrayBuffer>
   scale: number[] = [0, 2, 4, 6, 7, 9, 11, 12, 14]
   noiseNodes: AudioWorkletNode[] = []
   pannerNodes: PannerNode[] = []
   panIntervals: Array<number | NodeJS.Timeout> = []
   destroyed = false
   removeResumeListeners: (() => void) | null = null
+  meterFrame = 0
 
-  constructor(oscilatorsSize: number = 40, baseNote: number = 60) {
+  constructor(
+    audioLevelRef: React.MutableRefObject<number>,
+    oscilatorsSize: number = 40,
+    baseNote: number = 60,
+  ) {
     const context = new AudioContext()
     this.context = context
+    this.audioLevelRef = audioLevelRef
 
     const gainNode = context.createGain()
     gainNode.gain.value = 1
+    const analyserNode = context.createAnalyser()
+    analyserNode.fftSize = 256
+    analyserNode.smoothingTimeConstant = 0.78
     const limiter = context.createDynamicsCompressor()
     limiter.threshold.value = -1
     limiter.knee.value = 0
@@ -58,9 +74,12 @@ class Processor {
     limiter.attack.value = 0.003
     limiter.release.value = 0.25
 
-    gainNode.connect(limiter)
+    gainNode.connect(analyserNode)
+    analyserNode.connect(limiter)
     limiter.connect(context.destination)
     this.gainNode = gainNode
+    this.analyserNode = analyserNode
+    this.frequencyData = new Uint8Array(analyserNode.frequencyBinCount)
 
     const droneBus = context.createGain()
     droneBus.gain.value = voicePlayed ? 0.25 : 0.0001
@@ -124,12 +143,38 @@ class Processor {
       return
     }
 
+    // This component is mounted by the play button. Resuming here means the
+    // first press starts both the drone and its visual response together.
+    await this.context.resume()
+
     for (let i = 0; i < this.oscilatorsSize; i++) {
       const degree = Math.floor(Math.random() * this.scale.length)
       let frequency = mtof(this.baseNote + this.scale[degree])
       frequency += Math.random() * 4 - 2
       this.createNoiseGenerator(frequency)
     }
+
+    this.measureAudio()
+  }
+
+  measureAudio = () => {
+    if (this.destroyed) {
+      return
+    }
+
+    this.analyserNode.getByteFrequencyData(this.frequencyData)
+
+    // Weight the lower bins: the drone's fundamental motion is more useful as
+    // a visual pulse than the fine hiss in the upper frequencies.
+    let energy = 0
+    const bins = 20
+    for (let i = 1; i <= bins; i++) {
+      energy += this.frequencyData[i]
+    }
+
+    const target = Math.min(1, (energy / bins / 255) * 4.5)
+    this.audioLevelRef.current += (target - this.audioLevelRef.current) * 0.18
+    this.meterFrame = requestAnimationFrame(this.measureAudio)
   }
 
   createNoiseGenerator(frequency: number) {
@@ -174,6 +219,8 @@ class Processor {
 
   destroy() {
     this.destroyed = true
+    cancelAnimationFrame(this.meterFrame)
+    this.audioLevelRef.current = 0
 
     this.removeResumeListeners?.()
     this.voice?.dispose()
@@ -182,6 +229,7 @@ class Processor {
     this.pannerNodes.forEach((node) => node.disconnect())
     this.droneBus.disconnect()
     this.gainNode.disconnect()
+    this.analyserNode.disconnect()
     this.context.close()
   }
 }

--- a/apps/web/src/components/scene/default.frag
+++ b/apps/web/src/components/scene/default.frag
@@ -2,11 +2,8 @@
 // field: the important silhouette is made from smooth analytic shapes so it
 // stays legible at every resolution instead of turning into static.
 
-#ifdef GL_FRAGMENT_PRECISION_HIGH
-precision highp float;
-#else
-precision mediump float;
-#endif
+// star.glsl is prepended at compile time; it carries the precision block and
+// the starField() that shapes the middle of the rift.
 
 uniform vec2 u_resolution;
 uniform float u_time;
@@ -57,12 +54,28 @@ float seam(vec2 p) {
 }
 
 float riftMask(vec2 p, out float edgeDistance) {
+  // The tear opens into a four-pointed star at its centre. Tracking the seam
+  // keeps the star fixed to the rift as the seam wavers.
+  float sparkle = starField(vec2(p.x - seam(p), p.y));
+
+#ifdef RIFT_STAR_ONLY
+  // The rift is nothing but the star — no tails running off the top and
+  // bottom. Everything else in the scene is unchanged.
+  edgeDistance = sparkle;
+  return 1.0 - smoothstep(-0.008, 0.012, sparkle);
+#else
+  // p.y spans +/-1, so the taper and the cap both run past the frame: the tear
+  // still narrows towards its ends, but bleeds off the top and bottom edges
+  // instead of terminating on screen.
   float y = abs(p.y);
-  float taper = smoothstep(0.98, 0.14, y);
+  float taper = smoothstep(1.7, 0.14, y);
   float halfWidth = mix(0.012, 0.105, taper * taper);
-  edgeDistance = abs(p.x - seam(p)) - halfWidth;
-  float capped = max(edgeDistance, y - 0.92);
-  return 1.0 - smoothstep(-0.008, 0.012, capped);
+  float slit = abs(p.x - seam(p)) - halfWidth;
+  float capped = max(slit, y - 1.6);
+
+  edgeDistance = min(slit, sparkle);
+  return 1.0 - smoothstep(-0.008, 0.012, min(capped, sparkle));
+#endif
 }
 
 // Smooth curling bands behind the rupture. They supply scale and motion without
@@ -114,9 +127,21 @@ void main() {
   vec3 col = background(warped);
   col += accretion(warped);
 
-  float yFade = smoothstep(0.98, 0.14, abs(p.y));
+#ifdef RIFT_STAR_ONLY
+  // Nothing to fade vertically: the lips stay evenly lit to their points, and
+  // the star's field — which grows slowly along its own axes — is left to draw
+  // them out into the thin threads running off the top and bottom.
+  float yFade = 1.0;
+#else
+  float yFade = smoothstep(1.7, 0.14, abs(p.y));
+#endif
   float nearEdge = exp(-abs(edgeDistance) * 42.0) * yFade;
   float outerGlow = exp(-max(edgeDistance, 0.0) * 9.0) * yFade;
+#ifdef RIFT_STAR_ONLY
+  // Contain the broad halo radially so only the thin threads reach out, rather
+  // than the whole glow smearing into full-height tails.
+  outerGlow *= exp(-2.5 * dot(p, p));
+#endif
   float flicker = 0.72 + 0.28 * sin(p.y * 36.0 - u_time * 1.6);
 
   // Split-color ionisation makes both lips of the void feel physically torn.

--- a/apps/web/src/components/scene/default.frag
+++ b/apps/web/src/components/scene/default.frag
@@ -1,6 +1,8 @@
 // A clean, graphic cosmic rift. This deliberately avoids a ray-marched noise
 // field: the important silhouette is made from smooth analytic shapes so it
-// stays legible at every resolution instead of turning into static.
+// stays legible at every resolution instead of turning into static. The tear
+// itself opens onto a second space — a warm sunlit system seen through the
+// aperture — built from the same analytic discipline.
 
 // star.glsl is prepended at compile time; it carries the precision block and
 // the starField() that shapes the middle of the rift.
@@ -93,6 +95,149 @@ vec3 accretion(vec2 p) {
   return (hot + electric) * cut * (0.18 + 0.82 * sweep);
 }
 
+// ——— The space beyond the tear ———
+// The rift no longer opens onto flat black: through the aperture there is a
+// second space with its own sun, a tilted orbital plane, and a dark body
+// circling it. It is built from the same analytic shells and bands as the
+// outer scene — no noise — but on a warm palette nothing on our side uses,
+// so the interior reads as somewhere else, not a darker patch of here.
+
+// All interior periods divide the 256 s uniform wrap (2*PI / 256), so the
+// slow drifts never jump when u_time wraps around.
+const float INTERIOR_W = 0.0245437;
+
+// The interior's orbital plane leans against our screen axes: the space
+// beyond has its own horizon, not ours.
+const float INTERIOR_TILT = -0.38;
+
+float sq(float x) {
+  return x * x;
+}
+
+vec2 tilt2(vec2 v, float a) {
+  float c = cos(a);
+  float s = sin(a);
+  return vec2(c * v.x - s * v.y, s * v.x + c * v.y);
+}
+
+// Dust glints for the interior: the same cell trick as stars(), with a size
+// knob — the space beyond wants coarser, warmer motes than the outer
+// pinpricks, and their scale contrast is part of what sells the depth.
+float glints(vec2 p, float scale, float radius, float gate) {
+  vec2 cell = floor(p * scale);
+  vec2 f = fract(p * scale) - 0.5;
+  float seed = hash21(cell + 31.7);
+  vec2 offset = vec2(hash21(cell + 3.1), hash21(cell + 8.6)) - 0.5;
+  float d = length(f - offset * 0.7);
+  float point = 1.0 - smoothstep(radius * 0.35, radius, d);
+  float twinkle = 0.62 + 0.38 * sin(u_time * (0.5 + seed) + seed * 39.0);
+  return point * step(gate, seed) * twinkle;
+}
+
+vec3 interior(vec2 p, float edgeDistance) {
+  // The camera beyond the tear sways slowly, and each depth shifts by a
+  // different fraction of the sway. The differential slide of the layers
+  // against the fixed silhouette is the parallax that makes the aperture read
+  // as a window rather than a decal.
+  vec2 sway = vec2(
+    sin(u_time * (4.0 * INTERIOR_W)) +
+      0.55 * sin(u_time * (7.0 * INTERIOR_W) + 1.9),
+    cos(u_time * (3.0 * INTERIOR_W)) +
+      0.55 * sin(u_time * (6.0 * INTERIOR_W) + 4.1)
+  ) * 0.045;
+
+  // The distant sun sits just off the aperture's axis, so the view reads as
+  // looking at something rather than down a gunsight.
+  vec2 focus = vec2(0.04, 0.05);
+
+  // Three depths: the sun's neighbourhood, a nearer veil, and the far dust.
+  vec2 deep = p - focus - sway * 0.35;
+  vec2 near = p - focus - sway * 0.90;
+  vec2 far = p - sway * 0.15;
+
+  // Its own light: a white-gold core inside an amber corona — clearly warmer
+  // than anything on our side. It breathes on its own and answers the chant
+  // the way the seam does, so the beyond feels inhabited.
+  float breath = 1.0 + 0.09 * sin(u_time * (6.0 * INTERIOR_W) + 0.7) +
+                 0.30 * min(u_audioLevel, 1.0);
+  // The falloffs are tight because the whole view is only ~0.3 units across:
+  // the sun has to be a compact object inside darkness, not a wash that fills
+  // the aperture.
+  float r2 = dot(deep, deep);
+  vec3 col = vec3(0.020, 0.009, 0.006);
+  col += vec3(0.30, 0.115, 0.035) * exp(-40.0 * r2) * 0.42;
+  col += vec3(0.85, 0.38, 0.10) * exp(-110.0 * r2) * 0.9;
+  col += vec3(1.30, 0.98, 0.60) * exp(-260.0 * r2) * 2.2 * breath;
+  col += vec3(1.40, 1.30, 1.10) * exp(-900.0 * r2) * 1.4 * breath;
+
+  // A far colder sun, deep in the lower limb: proof the space beyond holds
+  // more than one light. It sits so close to the silhouette that the sway
+  // slides it behind the lip and back out again.
+  vec2 toCompanion = deep - vec2(-0.08, -0.21);
+  float c2 = dot(toCompanion, toCompanion);
+  col += vec3(0.45, 0.65, 1.05) * exp(-700.0 * c2) * 0.35;
+  col += vec3(0.75, 0.88, 1.15) * exp(-2600.0 * c2) * 0.7;
+
+  // The sun's orbital plane is the interior's horizon: a faint warm lane with
+  // a shimmer travelling along it, and a thin blazing flare line straight
+  // through the sun — an edge-on disc catching its light.
+  vec2 plane = tilt2(deep, INTERIOR_TILT);
+  float shimmer = 0.78 + 0.22 * sin(plane.x * 16.0 - u_time * (5.0 * INTERIOR_W));
+  float bandFall = exp(-sq(plane.y * 10.0)) * exp(-1.9 * abs(plane.x));
+  col += vec3(0.60, 0.22, 0.07) * bandFall * shimmer * 0.35;
+  col += vec3(1.05, 0.55, 0.22) * exp(-sq(plane.y * 26.0)) *
+         exp(-2.2 * abs(plane.x)) * 0.9 * breath;
+
+  // A dust lane curling around the sun, read in silhouette against the
+  // corona: the interior's structure comes from darkness, not more glow.
+  float rDeep = length(deep);
+  float aDeep = atan(deep.y, deep.x);
+  float spiralDeep = aDeep + 3.0 * log(rDeep + 0.05) - u_time * (2.0 * INTERIOR_W);
+  float duskLane = exp(-300.0 * sq(rDeep - (0.115 + 0.030 * sin(spiralDeep * 2.0))));
+  col *= 1.0 - duskLane * 0.4 * smoothstep(0.05, 0.09, rDeep);
+
+  // Far dust behind everything: finer and denser than the outer starfield, so
+  // the space beyond reads as receding much further than ours.
+  col += vec3(1.0, 0.82, 0.58) * glints(far + vec2(37.0, 11.0), 44.0, 0.10, 0.905) * 0.8;
+
+  // The dark body circling the sun in the tilted plane. On the near half of
+  // its orbit it swells and blocks the light outright; on the far half it
+  // shrinks and the corona washes over it. A backlit limb keeps it legible
+  // whenever it strays from the glare.
+  float orbitPhase = u_time * (3.0 * INTERIOR_W) + 2.1;
+  vec2 orbitPos =
+    tilt2(vec2(cos(orbitPhase), sin(orbitPhase) * 0.34) * 0.150, INTERIOR_TILT);
+  float front = smoothstep(0.25, -0.25, sin(orbitPhase));
+  float orbR = mix(0.026, 0.046, front);
+  vec2 orbVec = deep - orbitPos;
+  float dOrb = length(orbVec);
+  float body = 1.0 - smoothstep(orbR * 0.82, orbR, dOrb);
+  col *= 1.0 - body * mix(0.38, 0.94, front);
+  // When the body stands clear of the sun, only its sunward limb catches
+  // light; as it transits, the backlight wraps all the way around and the
+  // silhouette burns as an annular-eclipse ring.
+  vec2 sunward = -normalize(orbitPos + vec2(1e-4, 0.0));
+  float limbGlow = exp(-sq((dOrb - orbR) * 70.0));
+  float facing = max(dot(normalize(orbVec + vec2(1e-5, 0.0)), sunward), 0.0);
+  float wrap = mix(1.0, facing * facing, smoothstep(0.05, 0.16, length(orbitPos)));
+  col += vec3(1.25, 0.70, 0.32) * limbGlow * wrap * (0.30 + 0.85 * front);
+
+  // A nearer counter-rotating shell and coarse motes pass in front of the
+  // body, which is why they are added after it.
+  float rNear = length(near);
+  float aNear = atan(near.y, near.x);
+  float spiralNear = aNear - 2.6 * log(rNear + 0.07) + u_time * (3.0 * INTERIOR_W);
+  float shellB = exp(-80.0 * sq(rNear - (0.235 + 0.050 * sin(spiralNear * 3.0 + 1.3))));
+  col += vec3(0.42, 0.11, 0.10) * shellB * 0.5;
+  col += vec3(1.0, 0.70, 0.45) * glints(near * 0.8 + vec2(5.0, 71.0), 26.0, 0.16, 0.945) * 0.5;
+
+  // The throat of the tear shades the view near the lips: the interior dims
+  // where it meets the silhouette, which both seats it behind the aperture
+  // and gives the ionised rim something dark to burn against.
+  col *= 1.0 - 0.45 * exp(edgeDistance * 30.0);
+  return col;
+}
+
 vec3 background(vec2 p) {
   float vignette = dot(p, p);
   vec3 sky = mix(vec3(0.006, 0.008, 0.035), vec3(0.018, 0.035, 0.095),
@@ -157,10 +302,15 @@ void main() {
   col += rim * glitchTrace * 0.65;
   col += mix(leftFire, rightFire, 0.5) * outerGlow * 0.20;
 
-  // A black core with just enough reflected, dying light to preserve the
-  // contour; applying it last gives a genuinely bottomless central tear.
-  col = mix(col, vec3(0.0002, 0.0004, 0.0012), voidMask);
-  col += rim * nearEdge * voidMask * 0.20;
+  // The core is no longer bottomless black: the tear opens onto another
+  // space. Only pixels the mask can see pay for the interior, and applying it
+  // last keeps the aperture cleanly bounded by the silhouette.
+  vec3 beyond = vec3(0.0002, 0.0004, 0.0012);
+  if (voidMask > 0.002) {
+    beyond = interior(p, edgeDistance);
+  }
+  col = mix(col, beyond, voidMask);
+  col += rim * nearEdge * voidMask * 0.26;
 
   // Filmic compression retains the bright rim's colour instead of clipping it
   // to flat white, then a light gamma lift preserves the deep-space blacks.

--- a/apps/web/src/components/scene/default.frag
+++ b/apps/web/src/components/scene/default.frag
@@ -1,8 +1,6 @@
-// Recreates the landing page background. The CSS stacks two identical
-// `Root::before` aurora gradients with `mix-blend-mode: color-dodge` — the
-// outer one composites over a transparent backdrop, so the visible result is
-// the aurora radial gradient color-dodged over itself. The pool gradient in
-// the CSS sits beneath the opaque aurora layer and never shows.
+// A clean, graphic cosmic rift. This deliberately avoids a ray-marched noise
+// field: the important silhouette is made from smooth analytic shapes so it
+// stays legible at every resolution instead of turning into static.
 
 #ifdef GL_FRAGMENT_PRECISION_HIGH
 precision highp float;
@@ -12,116 +10,136 @@ precision mediump float;
 
 uniform vec2 u_resolution;
 uniform float u_time;
+uniform float u_audioLevel;
 
-// One `drift` keyframe: the aurora ellipse in viewport fractions (CSS
-// percentages / 100, y pointing down) and its palette in sRGB.
-struct Aurora {
-  vec2 center;
-  vec2 radius;
-  vec3 violet;
-  vec3 magenta;
-  vec3 indigo;
-  vec3 mist;
-};
+#define PI 3.14159265
 
-// Seconds per pass through the keyframes, as in `animation: drift 48s`.
-const float DURATION = 48.0;
-
-float linstep(float edge0, float edge1, float x) {
-  return clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+float hash21(vec2 p) {
+  p = fract(p * vec2(123.34, 456.21));
+  p += dot(p, p + 45.32);
+  return fract(p.x * p.y);
 }
 
-// Approximates the CSS `ease-in-out` timing function.
-float easeInOut(float t) {
-  return t * t * (3.0 - 2.0 * t);
+// A handful of very short, independently chosen rift segments misalign at a
+// time. The time gate is intentionally sparse, so this reads as a fault in the
+// tear rather than a layer of animated noise.
+float glitchBurst(float y) {
+  float tick = floor(u_time * 0.65);
+  float phase = fract(u_time * 0.65);
+  float event = step(0.77, hash21(vec2(tick, 1.7)));
+  float duration = 1.0 - smoothstep(0.035, 0.10, phase);
+  float segment = step(0.56, hash21(vec2(tick, floor((y + 1.0) * 12.0))));
+  return event * duration * segment;
 }
 
-Aurora blend(Aurora source, Aurora target, float t) {
-  return Aurora(
-    mix(source.center, target.center, t),
-    mix(source.radius, target.radius, t),
-    mix(source.violet, target.violet, t),
-    mix(source.magenta, target.magenta, t),
-    mix(source.indigo, target.indigo, t),
-    mix(source.mist, target.mist, t)
-  );
+// Sparse, crisp stars rather than full-screen grain. A single star can occupy
+// each cell, and only a small, deterministic subset of cells are lit.
+float stars(vec2 p, float scale) {
+  vec2 cell = floor(p * scale);
+  vec2 f = fract(p * scale) - 0.5;
+  float seed = hash21(cell);
+  vec2 offset = vec2(hash21(cell + 4.7), hash21(cell + 9.2)) - 0.5;
+  float d = length(f - offset * 0.72);
+  float point = 1.0 - smoothstep(0.008, 0.025, d);
+  return point * step(0.965, seed) * (0.55 + 0.45 * sin(u_time * (0.7 + seed) + seed * 22.0));
 }
 
-// Plays back the `drift` keyframes: ease-in-out between each pair,
-// alternating direction every pass.
-Aurora drift(float time) {
-  Aurora from = Aurora(
-    vec2(0.0, 0.0),
-    vec2(1.4, 1.4),
-    vec3(61.0, 27.0, 109.0) / 255.0,
-    vec3(228.0, 56.0, 220.0) / 255.0,
-    vec3(64.0, 75.0, 140.0) / 255.0,
-    vec3(121.0, 172.0, 187.0) / 255.0
-  );
-
-  Aurora third = Aurora(
-    vec2(0.12, 0.08),
-    vec2(1.65, 1.2),
-    vec3(74.0, 26.0, 134.0) / 255.0,
-    vec3(255.0, 47.0, 146.0) / 255.0,
-    vec3(61.0, 91.0, 176.0) / 255.0,
-    vec3(77.0, 215.0, 232.0) / 255.0
-  );
-
-  Aurora twoThirds = Aurora(
-    vec2(0.04, 0.18),
-    vec2(1.2, 1.7),
-    vec3(51.0, 32.0, 110.0) / 255.0,
-    vec3(196.0, 51.0, 255.0) / 255.0,
-    vec3(74.0, 63.0, 158.0) / 255.0,
-    vec3(98.0, 184.0, 217.0) / 255.0
-  );
-
-  Aurora to = Aurora(
-    vec2(0.16, 0.04),
-    vec2(1.5, 1.35),
-    vec3(61.0, 27.0, 109.0) / 255.0,
-    vec3(240.0, 56.0, 200.0) / 255.0,
-    vec3(64.0, 75.0, 140.0) / 255.0,
-    vec3(121.0, 172.0, 187.0) / 255.0
-  );
-
-  float cycle = mod(time / DURATION, 2.0);
-  float progress = cycle < 1.0 ? cycle : 2.0 - cycle;
-
-  if (progress < 0.33) {
-    return blend(from, third, easeInOut(progress / 0.33));
-  }
-
-  if (progress < 0.66) {
-    return blend(third, twoThirds, easeInOut((progress - 0.33) / 0.33));
-  }
-
-  return blend(twoThirds, to, easeInOut((progress - 0.66) / 0.34));
+// The seam of the tear is intentionally irregular, but its motion is slow and
+// continuous: it reads as stressed spacetime, not procedural turbulence.
+float seam(vec2 p) {
+  float tick = floor(u_time * 0.65);
+  float lane = floor((p.y + 1.0) * 12.0);
+  float direction = hash21(vec2(tick, lane)) * 2.0 - 1.0;
+  return 0.030 * sin(p.y * 7.0 + 0.35 * sin(u_time * 0.25)) +
+         0.018 * sin(p.y * 17.0 - u_time * 0.18) +
+         u_audioLevel * 0.004 * sin(p.y * 58.0 - u_time * 13.0) +
+         glitchBurst(p.y) * direction * 0.028;
 }
 
-// The aurora radial gradient, with the color stops from the CSS:
-// violet 30%, magenta 65%, indigo 80%, mist 110%.
-vec3 gradient(Aurora aurora, vec2 point) {
-  float t = length((point - aurora.center) / aurora.radius);
-
-  vec3 color = mix(aurora.violet, aurora.magenta, linstep(0.3, 0.65, t));
-  color = mix(color, aurora.indigo, linstep(0.65, 0.8, t));
-
-  return mix(color, aurora.mist, linstep(0.8, 1.1, t));
+float riftMask(vec2 p, out float edgeDistance) {
+  float y = abs(p.y);
+  float taper = smoothstep(0.98, 0.14, y);
+  float halfWidth = mix(0.012, 0.105, taper * taper);
+  edgeDistance = abs(p.x - seam(p)) - halfWidth;
+  float capped = max(edgeDistance, y - 0.92);
+  return 1.0 - smoothstep(-0.008, 0.012, capped);
 }
 
-vec3 colorDodge(vec3 backdrop, vec3 source) {
-  return min(vec3(1.0), backdrop / max(1.0 - source, 1e-4));
+// Smooth curling bands behind the rupture. They supply scale and motion without
+// covering the whole screen in texture.
+vec3 accretion(vec2 p) {
+  float r = length(p * vec2(0.82, 1.18));
+  float a = atan(p.y, p.x);
+  float spiral = a + 2.8 * log(r + 0.16) - u_time * 0.13;
+  float bandA = exp(-36.0 * pow(r - (0.43 + 0.050 * sin(spiral * 2.0)), 2.0));
+  float bandB = exp(-62.0 * pow(r - (0.62 + 0.035 * sin(spiral * 3.0 + 1.4)), 2.0));
+  float sweep = smoothstep(-0.95, 0.7, sin(a - 0.45));
+  float cut = smoothstep(1.20, 0.20, r);
+  vec3 hot = vec3(1.15, 0.18, 0.045) * bandA;
+  vec3 electric = vec3(0.06, 0.42, 1.28) * bandB;
+  return (hot + electric) * cut * (0.18 + 0.82 * sweep);
+}
+
+vec3 background(vec2 p) {
+  float vignette = dot(p, p);
+  vec3 sky = mix(vec3(0.006, 0.008, 0.035), vec3(0.018, 0.035, 0.095),
+                 exp(-1.4 * vignette));
+
+  // Two broad, low-frequency veils give the void depth without noise.
+  float blueVeil = exp(-7.0 * pow(p.y + 0.34 + 0.11 * sin(p.x * 2.1), 2.0));
+  float redVeil = exp(-10.0 * pow(p.y - 0.48 - 0.08 * sin(p.x * 3.0), 2.0));
+  sky += vec3(0.015, 0.075, 0.21) * blueVeil * (0.25 + 0.75 * exp(-p.x * p.x));
+  sky += vec3(0.11, 0.009, 0.045) * redVeil * 0.45;
+
+  float starfield = stars(p + vec2(u_time * 0.002, 0.0), 21.0) +
+                    stars(p * 1.7 - vec2(u_time * 0.001, 0.0), 34.0) * 0.65;
+  return sky + vec3(0.52, 0.70, 1.0) * starfield;
 }
 
 void main() {
-  // CSS coordinates: origin top left, y pointing down.
-  vec2 point = gl_FragCoord.xy / u_resolution;
-  point.y = 1.0 - point.y;
+  vec2 p = (2.0 * gl_FragCoord.xy - u_resolution.xy) / u_resolution.y;
+  p.y -= 0.04;
 
-  Aurora aurora = drift(u_time);
-  vec3 color = gradient(aurora, point);
+  // Audio only agitates the seam itself (in seam()), leaving the surrounding
+  // accretion aura absolutely still and making each pulse feel contained.
+  float audioPulse = min(u_audioLevel, 1.0);
 
-  gl_FragColor = vec4(colorDodge(color, color), 1.0);
+  // Weak lensing pulls distant light into a curve around the rupture.
+  vec2 lensVector = p - vec2(0.0, 0.02);
+  float lensFalloff = exp(-3.0 * dot(lensVector, lensVector));
+  vec2 warped = p + normalize(lensVector + vec2(0.0001, 0.0)) * 0.055 * lensFalloff;
+
+  float edgeDistance;
+  float voidMask = riftMask(p, edgeDistance);
+  vec3 col = background(warped);
+  col += accretion(warped);
+
+  float yFade = smoothstep(0.98, 0.14, abs(p.y));
+  float nearEdge = exp(-abs(edgeDistance) * 42.0) * yFade;
+  float outerGlow = exp(-max(edgeDistance, 0.0) * 9.0) * yFade;
+  float flicker = 0.72 + 0.28 * sin(p.y * 36.0 - u_time * 1.6);
+
+  // Split-color ionisation makes both lips of the void feel physically torn.
+  float side = step(seam(p), p.x);
+  vec3 leftFire = vec3(1.35, 0.095, 0.018);
+  vec3 rightFire = vec3(0.025, 0.43, 1.55);
+  vec3 rim = mix(leftFire, rightFire, side);
+  float travellingPulse = 0.5 + 0.5 * sin(p.y * 58.0 - u_time * 13.0);
+  float glitchTrace = glitchBurst(p.y) *
+                      (1.0 - smoothstep(0.012, 0.045, abs(edgeDistance)));
+  col += rim * nearEdge *
+         (1.6 + 1.4 * flicker + audioPulse * travellingPulse * 0.28);
+  col += rim * glitchTrace * 0.65;
+  col += mix(leftFire, rightFire, 0.5) * outerGlow * 0.20;
+
+  // A black core with just enough reflected, dying light to preserve the
+  // contour; applying it last gives a genuinely bottomless central tear.
+  col = mix(col, vec3(0.0002, 0.0004, 0.0012), voidMask);
+  col += rim * nearEdge * voidMask * 0.20;
+
+  // Filmic compression retains the bright rim's colour instead of clipping it
+  // to flat white, then a light gamma lift preserves the deep-space blacks.
+  col = col / (1.0 + col);
+  col = pow(col, vec3(0.82));
+  gl_FragColor = vec4(col, 1.0);
 }

--- a/apps/web/src/components/scene/gl.ts
+++ b/apps/web/src/components/scene/gl.ts
@@ -1,0 +1,67 @@
+export const createShader = (
+  gl: WebGLRenderingContext,
+  type: number,
+  source: string,
+) => {
+  const shader = gl.createShader(type)
+
+  if (!shader) {
+    return
+  }
+
+  gl.shaderSource(shader, source)
+  gl.compileShader(shader)
+
+  const success = gl.getShaderParameter(shader, gl.COMPILE_STATUS)
+  if (success) {
+    return shader
+  }
+
+  console.log(gl.getShaderInfoLog(shader))
+  gl.deleteShader(shader)
+}
+
+export const createProgram = (
+  gl: WebGLRenderingContext,
+  vertexShader: WebGLShader,
+  fragmentShader: WebGLShader,
+) => {
+  const program = gl.createProgram()
+
+  if (!program || !vertexShader || !fragmentShader) {
+    return
+  }
+
+  gl.attachShader(program, vertexShader)
+  gl.attachShader(program, fragmentShader)
+  gl.linkProgram(program)
+
+  const success = gl.getProgramParameter(program, gl.LINK_STATUS)
+
+  if (success) {
+    return program
+  }
+
+  console.log(gl.getProgramInfoLog(program))
+  gl.deleteProgram(program)
+}
+
+// Render at device resolution but cap the pixel ratio, with a scale knob to
+// trade sharpness for performance if a machine struggles.
+const RENDER_SCALE = 1
+
+export const resize = (canvas: HTMLCanvasElement) => {
+  const { width, height, clientWidth, clientHeight } = canvas
+
+  const scale = Math.min(window.devicePixelRatio, 2) * RENDER_SCALE
+  const displayWidth = Math.floor(clientWidth * scale)
+  const displayHeight = Math.floor(clientHeight * scale)
+
+  if (width !== displayWidth || height !== displayHeight) {
+    canvas.width = displayWidth
+    canvas.height = displayHeight
+  }
+}
+
+// A single triangle covering clip space.
+export const FULLSCREEN_TRIANGLE = [-1, -1, 3, -1, -1, 3]

--- a/apps/web/src/components/scene/index.tsx
+++ b/apps/web/src/components/scene/index.tsx
@@ -1,18 +1,24 @@
+'use client'
+
 import styled from '@emotion/styled'
 import * as React from 'react'
 
 import fragmentShaderSource from './default.frag'
 import vertexShaderSource from './default.vert'
+import { FULLSCREEN_TRIANGLE, createProgram, createShader, resize } from './gl'
+import starSource from './star.glsl'
 
 // The wind scroll and camera yaw are wrapped to this period so shader float
 // precision holds up as the clock grows. Matches CYCLE_SECONDS in the shader.
 const CYCLE = 256
 
 export interface SceneProps {
-  audioLevelRef: React.MutableRefObject<number>
+  audioLevelRef?: React.MutableRefObject<number>
+  /** Render the rift as the bare star, without its top and bottom tails. */
+  starOnly?: boolean
 }
 
-export const Scene: React.FC<SceneProps> = ({ audioLevelRef }) => {
+export const Scene: React.FC<SceneProps> = ({ audioLevelRef, starOnly }) => {
   const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
 
   React.useEffect(() => {
@@ -36,7 +42,9 @@ export const Scene: React.FC<SceneProps> = ({ audioLevelRef }) => {
       const fragmentShader = createShader(
         gl,
         gl.FRAGMENT_SHADER,
-        fragmentShaderSource,
+        (starOnly ? '#define RIFT_STAR_ONLY 1\n' : '') +
+          starSource +
+          fragmentShaderSource,
       )
 
       if (!vertexShader || !fragmentShader) {
@@ -49,8 +57,6 @@ export const Scene: React.FC<SceneProps> = ({ audioLevelRef }) => {
         return
       }
 
-      // A single triangle covering clip space.
-      const positions = [-1, -1, 3, -1, -1, 3]
       const positionAttributeLocation = gl.getAttribLocation(
         program,
         'a_position',
@@ -59,7 +65,7 @@ export const Scene: React.FC<SceneProps> = ({ audioLevelRef }) => {
       gl.bindBuffer(gl.ARRAY_BUFFER, positionBuffer)
       gl.bufferData(
         gl.ARRAY_BUFFER,
-        new Float32Array(positions),
+        new Float32Array(FULLSCREEN_TRIANGLE),
         gl.STATIC_DRAW,
       )
 
@@ -89,7 +95,7 @@ export const Scene: React.FC<SceneProps> = ({ audioLevelRef }) => {
           timeLocation,
           reducedMotion.matches ? 0 : (now / 1000) % CYCLE,
         )
-        gl.uniform1f(audioLevelLocation, audioLevelRef.current)
+        gl.uniform1f(audioLevelLocation, audioLevelRef?.current ?? 0)
         gl.drawArrays(gl.TRIANGLES, 0, 3)
 
         frame = requestAnimationFrame(render)
@@ -131,75 +137,9 @@ export const Scene: React.FC<SceneProps> = ({ audioLevelRef }) => {
       canvas.removeEventListener('webglcontextrestored', handleContextRestored)
       dispose?.()
     }
-  }, [audioLevelRef])
+  }, [audioLevelRef, starOnly])
 
   return <Canvas ref={canvasRef} />
-}
-
-const createShader = (
-  gl: WebGLRenderingContext,
-  type: number,
-  source: string,
-) => {
-  const shader = gl.createShader(type)
-
-  if (!shader) {
-    return
-  }
-
-  gl.shaderSource(shader, source)
-  gl.compileShader(shader)
-
-  const success = gl.getShaderParameter(shader, gl.COMPILE_STATUS)
-  if (success) {
-    return shader
-  }
-
-  console.log(gl.getShaderInfoLog(shader))
-  gl.deleteShader(shader)
-}
-
-const createProgram = (
-  gl: WebGLRenderingContext,
-  vertexShader: WebGLShader,
-  fragmentShader: WebGLShader,
-) => {
-  const program = gl.createProgram()
-
-  if (!program || !vertexShader || !fragmentShader) {
-    return
-  }
-
-  gl.attachShader(program, vertexShader)
-  gl.attachShader(program, fragmentShader)
-  gl.linkProgram(program)
-
-  const success = gl.getProgramParameter(program, gl.LINK_STATUS)
-
-  if (success) {
-    return program
-  }
-
-  console.log(gl.getProgramInfoLog(program))
-  gl.deleteProgram(program)
-}
-
-// Raymarched clouds cost far more per pixel than the old 2D gradient. Render at
-// device resolution but cap the pixel ratio, with a scale knob to trade
-// sharpness for performance if a machine struggles.
-const RENDER_SCALE = 1
-
-const resize = (canvas: HTMLCanvasElement) => {
-  const { width, height, clientWidth, clientHeight } = canvas
-
-  const scale = Math.min(window.devicePixelRatio, 2) * RENDER_SCALE
-  const displayWidth = Math.floor(clientWidth * scale)
-  const displayHeight = Math.floor(clientHeight * scale)
-
-  if (width !== displayWidth || height !== displayHeight) {
-    canvas.width = displayWidth
-    canvas.height = displayHeight
-  }
 }
 
 const Canvas = styled.canvas`

--- a/apps/web/src/components/scene/index.tsx
+++ b/apps/web/src/components/scene/index.tsx
@@ -4,11 +4,15 @@ import * as React from 'react'
 import fragmentShaderSource from './default.frag'
 import vertexShaderSource from './default.vert'
 
-// One pass through the `drift` keyframes and back (48s, alternating), after
-// which the animation repeats exactly.
-const CYCLE = 96
+// The wind scroll and camera yaw are wrapped to this period so shader float
+// precision holds up as the clock grows. Matches CYCLE_SECONDS in the shader.
+const CYCLE = 256
 
-export const Scene: React.FC = () => {
+export interface SceneProps {
+  audioLevelRef: React.MutableRefObject<number>
+}
+
+export const Scene: React.FC<SceneProps> = ({ audioLevelRef }) => {
   const canvasRef = React.useRef<HTMLCanvasElement | null>(null)
 
   React.useEffect(() => {
@@ -72,6 +76,7 @@ export const Scene: React.FC = () => {
 
       const resolutionLocation = gl.getUniformLocation(program, 'u_resolution')
       const timeLocation = gl.getUniformLocation(program, 'u_time')
+      const audioLevelLocation = gl.getUniformLocation(program, 'u_audioLevel')
 
       const render = (now: DOMHighResTimeStamp) => {
         resize(canvas)
@@ -84,6 +89,7 @@ export const Scene: React.FC = () => {
           timeLocation,
           reducedMotion.matches ? 0 : (now / 1000) % CYCLE,
         )
+        gl.uniform1f(audioLevelLocation, audioLevelRef.current)
         gl.drawArrays(gl.TRIANGLES, 0, 3)
 
         frame = requestAnimationFrame(render)
@@ -125,7 +131,7 @@ export const Scene: React.FC = () => {
       canvas.removeEventListener('webglcontextrestored', handleContextRestored)
       dispose?.()
     }
-  }, [])
+  }, [audioLevelRef])
 
   return <Canvas ref={canvasRef} />
 }
@@ -178,11 +184,17 @@ const createProgram = (
   gl.deleteProgram(program)
 }
 
+// Raymarched clouds cost far more per pixel than the old 2D gradient. Render at
+// device resolution but cap the pixel ratio, with a scale knob to trade
+// sharpness for performance if a machine struggles.
+const RENDER_SCALE = 1
+
 const resize = (canvas: HTMLCanvasElement) => {
   const { width, height, clientWidth, clientHeight } = canvas
 
-  const displayWidth = Math.floor(clientWidth * window.devicePixelRatio)
-  const displayHeight = Math.floor(clientHeight * window.devicePixelRatio)
+  const scale = Math.min(window.devicePixelRatio, 2) * RENDER_SCALE
+  const displayWidth = Math.floor(clientWidth * scale)
+  const displayHeight = Math.floor(clientHeight * scale)
 
   if (width !== displayWidth || height !== displayHeight) {
     canvas.width = displayWidth

--- a/apps/web/src/components/scene/star.glsl
+++ b/apps/web/src/components/scene/star.glsl
@@ -1,0 +1,23 @@
+// Shared chunk: prepended to every fragment shader that needs the star, so the
+// shape has a single definition. It carries the precision block, which is why
+// the shaders that consume it do not declare their own.
+
+#ifdef GL_FRAGMENT_PRECISION_HIGH
+precision highp float;
+#else
+precision mediump float;
+#endif
+
+// The four-pointed star at the heart of the rift. Half-extent in screen units
+// (y spans +/-1), and an exponent below 1 that pulls the edges concave: 1.0
+// would be a plain diamond, lower values sharpen the points.
+const vec2 STAR_RADIUS = vec2(0.30, 0.44);
+const float STAR_SHARPNESS = 0.64;
+
+// Negative inside the star, positive outside, scaled back to roughly screen
+// units so callers can use the same soft-edge thresholds as everything else.
+float starField(vec2 p) {
+  vec2 q = max(abs(p) / STAR_RADIUS, 1e-6);
+  return (pow(q.x, STAR_SHARPNESS) + pow(q.y, STAR_SHARPNESS) - 1.0) *
+         STAR_RADIUS.x;
+}


### PR DESCRIPTION
The landing background becomes a WebGL rift scene shaped around a four-pointed star, and the first listen now opens with a synthesised throat-chant invocation in Croatian that crossfades into the drone. Along the way it adds a `/chant` tuning console for the invocation's timing and voice character, and a `/shape` route that previews the bare star.

This is a large branch — 41 commits of iteration on the shader, the chant, and the mix. The instrument-style frame overlay that was prototyped along the way is deliberately left out.